### PR TITLE
Add reactive todo completion functionality to recall subsystem

### DIFF
--- a/app/Actions/Commands/RecallCommand.php
+++ b/app/Actions/Commands/RecallCommand.php
@@ -36,15 +36,12 @@ class RecallCommand implements HandlesCommand
             );
         }
 
-        $fragments = $results->map(fn ($f) => [
-            'type' => $f->type,
-            'message' => $f->message,
-        ])->toArray();
+        $fragmentIds = $results->pluck('id')->toArray();
 
         return new CommandResponse(
             message: "✅ Recalled {$results->count()} fragment(s) of type `{$type}`.",
-            type: 'system',
-            fragments: $fragments,
+            type: 'recall',
+            fragments: $fragmentIds,
             shouldResetChat: true,
         );
     }

--- a/app/Livewire/TodoItem.php
+++ b/app/Livewire/TodoItem.php
@@ -12,10 +12,17 @@ class TodoItem extends Component
     public function toggle()
     {
         $state = $this->fragment->state ?? [];
-
-        $state['status'] = ($state['status'] ?? 'open') === 'complete'
-            ? 'open'
-            : 'complete';
+        $newStatus = ($state['status'] ?? 'open') === 'complete' ? 'open' : 'complete';
+        
+        $state['status'] = $newStatus;
+        
+        // Add completion timestamp when marking as complete
+        if ($newStatus === 'complete') {
+            $state['completed_at'] = now()->toISOString();
+        } else {
+            // Remove completion timestamp when reopening
+            unset($state['completed_at']);
+        }
 
         $this->fragment->state = $state;
         $this->fragment->save();

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -33,13 +33,17 @@
                     @endforeach
 
                     @if (!empty($recalledTodos))
-                            {{-- Recalled Todos --}}
-                            <h1 class="text-red-500 text-sm">Recalled Todos Count: {{ count($recalledTodos) }}</h1>
+                        {{-- Recalled Todos --}}
+                        @php
+                            $todoFragments = $this->getTodoFragments();
+                        @endphp
 
-                            <h2 class="text-lg font-semibold text-gray-300 mb-2">Todos:</h2>
-                        <ul class="list-none space-y-1">
-                            @foreach ($recalledTodos as $entry)
-                                <livewire:todo-item :fragment="\App\Models\Fragment::find($entry['id'])" :key="$entry['id']" />
+                        <h2 class="text-lg font-semibold text-blue-400 mb-3 mt-4">📋 Todos ({{ $todoFragments->count() }})</h2>
+                        <ul class="list-none space-y-2">
+                            @foreach ($todoFragments as $fragment)
+                                <li wire:key="todo-{{ $fragment->id }}">
+                                    <livewire:todo-item :fragment="$fragment" :key="'todo-'.$fragment->id" />
+                                </li>
                             @endforeach
                         </ul>
                     @endif

--- a/resources/views/livewire/todo-item.blade.php
+++ b/resources/views/livewire/todo-item.blade.php
@@ -1,11 +1,16 @@
-<li class="flex items-center gap-2 py-0">
+<div class="flex items-center gap-3 py-1 transition-all duration-300 ease-in-out hover:bg-gray-800 hover:bg-opacity-30 rounded px-2 -mx-2">
     <input
         type="checkbox"
         wire:click="toggle"
         @checked(($fragment->state['status'] ?? 'open') === 'complete')
-        class="h-4 w-4 text-green-500 rounded border-gray-300 focus:ring-green-500"
+        class="h-4 w-4 text-green-500 rounded border-gray-300 focus:ring-green-500 transition-all duration-200"
     />
-    <span class="{{ ($fragment->state['status'] ?? 'open') === 'complete' ? 'line-through text-gray-500' : '' }}">
+    <span class="transition-all duration-300 ease-in-out {{ ($fragment->state['status'] ?? 'open') === 'complete' ? 'line-through text-gray-400' : 'text-gray-900' }}">
         {{ $fragment->message }}
     </span>
-</li>
+    @if (($fragment->state['status'] ?? 'open') === 'complete' && isset($fragment->state['completed_at']))
+        <span class="text-xs text-gray-600 ml-auto opacity-60 transition-opacity duration-300">
+            {{ \Carbon\Carbon::parse($fragment->state['completed_at'])->diffForHumans() }}
+        </span>
+    @endif
+</div>


### PR DESCRIPTION
## Summary
- Enhanced recall subsystem with interactive todo completion
- Todos now store completion timestamps in Fragment state metadata
- Simplified single-list display with in-place visual feedback
- Fixed text colors for proper visibility on white background

## Changes Made
- **RecallCommand**: Return Fragment IDs for dynamic state management
- **ChatInterface**: Added dynamic Fragment loading and todo display logic
- **TodoItem**: Enhanced with completion timestamps and visual transitions
- **Templates**: Simplified to single list with fade effects for completed items

## Features
- ✅ Click todos to mark complete/incomplete with immediate visual feedback
- ✅ Completion timestamps stored in Fragment state
- ✅ Proper text contrast (dark for active, faded for completed)
- ✅ CSS transitions for smooth state changes
- ✅ Simplified UX without complex section movements

🤖 Generated with [Claude Code](https://claude.ai/code)