### PR TITLE
Redesign ChatInterface with modern 4-column layout

### DIFF
--- a/app/Filament/Resources/FragmentResource/Pages/ChatInterface.php
+++ b/app/Filament/Resources/FragmentResource/Pages/ChatInterface.php
@@ -38,7 +38,7 @@ class ChatInterface extends Page
 
     public function getLayout() : string
     {
-        return 'vendor.filament-panels.components.layout.base'; // basic Filament layout
+        return 'layouts.chat-interface';
     }
 
     protected static ?string $title      = null;
@@ -181,6 +181,30 @@ class ChatInterface extends Page
             ->get();
     }
 
+
+    public function injectCommand($command)
+    {
+        $this->input = $command;
+    }
+
+    public function showSession()
+    {
+        if ($this->currentSession) {
+            $sessionDetails = "Session Details:\n\n";
+            $sessionDetails .= "**Identifier:** " . ($this->currentSession['identifier'] ?? 'Unnamed Session') . "\n";
+            $sessionDetails .= "**Vault:** " . ($this->currentSession['vault'] ?? 'N/A') . "\n";
+            $sessionDetails .= "**Type:** " . ($this->currentSession['type'] ?? 'N/A') . "\n";
+            
+            if (isset($this->currentSession['created_at'])) {
+                $sessionDetails .= "**Created:** " . \Carbon\Carbon::parse($this->currentSession['created_at'])->diffForHumans() . "\n";
+            }
+            
+            $this->chatMessages[] = [
+                'type'    => 'system',
+                'message' => $sessionDetails,
+            ];
+        }
+    }
 
     public function onFragmentProcessed( $payload )
     {

--- a/resources/views/components/chat-message.blade.php
+++ b/resources/views/components/chat-message.blade.php
@@ -1,0 +1,32 @@
+@props(['message', 'type' => 'user', 'timestamp' => null])
+
+<div class="flex items-start space-x-3">
+    <div class="w-8 h-8 {{ $type === 'user' ? 'bg-hot-pink' : ($type === 'system' ? 'bg-neon-cyan' : 'bg-electric-blue') }} rounded-full flex items-center justify-center text-white text-sm font-medium pixel-card {{ $type === 'user' ? 'glow-pink' : ($type === 'system' ? 'glow-cyan' : 'glow-blue') }}">
+        @if($type === 'user')
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+            </svg>
+        @elseif($type === 'system')
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+            </svg>
+        @else
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+            </svg>
+        @endif
+    </div>
+    <div class="flex-1">
+        <div class="bg-surface-card rounded-pixel p-4 pixel-card border-thin 
+            {{ $type === 'user' ? 'border-hot-pink/30 pixel-card-pink glow-pink' : 
+               ($type === 'system' ? 'border-neon-cyan/30 pixel-card-cyan glow-cyan' : 
+                'border-electric-blue/30 pixel-card-blue glow-blue') }}">
+            <div class="prose prose-sm dark:prose-invert max-w-none text-text-primary">
+                {{ $slot }}
+            </div>
+        </div>
+        <div class="text-xs text-text-muted mt-1">
+            {{ $timestamp ?? 'Just now' }}
+        </div>
+    </div>
+</div>

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -1,120 +1,236 @@
-<x-filament-panels::page class="max-w-3xl mx-auto rounded border mt-10 bg-white">
-
-    <div class="h-screen w-full bg-zinc-950 text-black flex flex-col pt-[10px]">
-
-        @if ($currentSession)
-            <div class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 p-2 rounded mb-4 flex items-center justify-between">
-                <div>
-                    <strong>Session:</strong> {{ $currentSession['identifier'] ?? 'Unnamed Session' }}
-                    <span class="text-sm text-gray-500 ml-2">(vault: {{ $currentSession['vault'] }}, type: {{ $currentSession['type'] }})</span>
-                </div>
-                <button wire:click="showSession" class="text-sm underline hover:text-green-600">Details</button>
+<!-- Main 4-Column Layout -->
+<div class="h-screen flex">
+    
+    <!-- Left Column 1: Ribbon -->
+    <div class="w-16 bg-surface-2 border-r border-thin border-hot-pink/30 flex flex-col items-center py-4">
+        <!-- Fe Periodic Element -->
+        <div class="relative">
+            <!-- Main hot pink square -->
+            <div class="w-10 h-10 bg-hot-pink rounded-pixel flex items-center justify-center relative z-10 pixel-card glow-pink">
+                <span class="text-white font-bold text-xl font-mono leading-none">Fe</span>
             </div>
-        @endif
-            <div
-                id="drift-avatar"
-                x-data="{ avatar: '/interface/avatars/default/default.png' }"
-                x-init="$watch('avatar', value => {
-    $el.querySelector('img').src = value;
-  })"
-                class="top-[calc(100%-150px)] right-6 z-50 float-right bg-black w-20 rounded-full shadow-lg p-1 border-4 border-blue-400 animate-pulse transition-all"
-            >
-                <img :src="avatar" alt="Drift Avatar" class="float-right bg-black  rounded-full w-15 h-15 object-cover transition duration-500">
-            </div>
-        {{-- Chat Output --}}
-            <div id="chat-output" class="flex-1 overflow-y-auto">
-            <div class="space-y-2 divide-y divide-zinc-800">
-                {{-- Normal Chat --}}
-                <div class="mt-6">
-                    @foreach ($chatMessages as $entry)
-                        <x-chat-markdown>
-                            {{ $entry['message'] }}
-                        </x-chat-markdown>
-                    @endforeach
+            <!-- Offset outline -->
+            <div class="absolute -top-0.5 -left-0.5 w-11 h-11 border-thin border-electric-blue rounded-pixel"></div>
+        </div>
+        
+        <!-- Additional ribbon items -->
+        <div class="mt-8 space-y-3">
+            <button class="w-8 h-8 bg-surface-card rounded-pixel pixel-card border-thin border-hot-pink/30 flex items-center justify-center hover:bg-hot-pink/10 transition-colors glow-pink">
+                <svg class="w-4 h-4 text-hot-pink" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+                </svg>
+            </button>
+            <button class="w-8 h-8 bg-surface-card rounded-pixel pixel-card border-thin border-electric-blue/30 flex items-center justify-center hover:bg-electric-blue/10 transition-colors glow-blue">
+                <svg class="w-4 h-4 text-electric-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+            </button>
+        </div>
+    </div>
 
-                    @if (!empty($recalledTodos))
-                        {{-- Recalled Todos --}}
-                        @php
-                            $todoFragments = $this->getTodoFragments();
-                        @endphp
-
-                        <h2 class="text-lg font-semibold text-blue-400 mb-3 mt-4">📋 Todos ({{ $todoFragments->count() }})</h2>
-                        <ul class="list-none space-y-2">
-                            @foreach ($todoFragments as $fragment)
-                                <li wire:key="todo-{{ $fragment->id }}">
-                                    <livewire:todo-item :fragment="$fragment" :key="'todo-'.$fragment->id" />
-                                </li>
-                            @endforeach
-                        </ul>
-                    @endif
-
+    <!-- Left Column 2: Navigation -->
+    <div class="w-72 bg-surface-2 border-r border-thin border-electric-blue/30 flex flex-col">
+        <!-- Projects/Context Sessions -->
+        <div class="p-4 border-b border-thin border-hot-pink/20">
+            <div class="pixel-card pixel-card-pink p-3 glow-pink">
+                <h3 class="text-sm font-medium text-text-secondary mb-2">Active Project</h3>
+                <div class="bg-surface-elevated rounded-pixel p-2 pixel-card border-thin border-hot-pink/30">
+                    <div class="flex items-center justify-between">
+                        <span class="text-sm font-medium text-hot-pink">Seer Interface</span>
+                        <span class="text-xs text-electric-blue">v2.0</span>
+                    </div>
+                    <div class="text-xs text-text-muted mt-1">Chat Interface Redesign</div>
                 </div>
-
-
-
             </div>
         </div>
 
+        <!-- Session Indicator -->
+        @if ($currentSession)
+        <div class="p-4 border-b border-thin border-neon-cyan/20">
+            <div class="pixel-card pixel-card-cyan p-3 glow-cyan">
+                <div class="flex items-center justify-between mb-2">
+                    <h3 class="text-sm font-medium text-neon-cyan">Active Session</h3>
+                    <button wire:click="showSession" class="text-xs text-text-muted hover:text-neon-cyan">Details</button>
+                </div>
+                <div class="text-sm font-medium text-text-primary">{{ $currentSession['identifier'] ?? 'Unnamed Session' }}</div>
+                <div class="text-xs text-text-muted mt-1">{{ $currentSession['vault'] }} • {{ $currentSession['type'] }}</div>
+            </div>
+        </div>
+        @endif
 
-        {{-- Input Bar --}}
-        <form id="chat-form" x-data wire:submit.prevent="handleInput" class="p-1">
+        <!-- Chat History Placeholder -->
+        <div class="flex-1 p-4 overflow-y-auto">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-sm font-medium text-text-secondary">Recent Chats</h3>
+                <button class="text-xs text-text-muted hover:text-text-secondary">View All</button>
+            </div>
+            
+            <div class="space-y-2">
+                <!-- Current Chat Item -->
+                <div class="pixel-card pixel-card-pink p-3 bg-hot-pink/20 border-hot-pink/60 glow-pink">
+                    <div class="flex items-start justify-between">
+                        <div class="flex-1">
+                            <div class="text-sm font-medium text-text-primary">Current Chat</div>
+                            <div class="text-xs text-text-muted mt-1">{{ count($chatMessages) }} messages</div>
+                        </div>
+                        <div class="text-xs text-hot-pink ml-2 font-medium">Now</div>
+                    </div>
+                </div>
+            </div>
+        </div>
 
+        <!-- New Chat & Commands -->
+        <div class="p-4 border-t border-thin border-electric-blue/20 space-y-3">
+            <button 
+                x-data
+                x-on:click="$dispatch('open-command-palette')"
+                class="w-full bg-hot-pink text-white py-2 px-4 rounded-pixel hover:bg-hot-pink/90 transition-colors text-sm font-medium pixel-card glow-pink"
+            >
+                ⚡ Commands
+            </button>
+        </div>
+    </div>
 
-        <textarea
-            x-data
-            wire:model.defer="input"
-            wire:keydown.enter.prevent="
-                $el.value = '';
-                $nextTick(() => {
-                    document.getElementById('chat-form')?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-                });
-            "
-            class="
-                w-full
-                p-2
-                rounded
-                bg-zinc-800
-                text-back border
-                border-zinc-700
-                resize-none
-                "
-            rows="3"
-        >
-        </textarea>
+    <!-- Middle Column: Chat Interface -->
+    <div class="flex-1 flex flex-col bg-surface">
+        <!-- Row 1: Header -->
+        <div class="h-16 bg-surface-2 border-b border-thin border-hot-pink/30 flex items-center justify-between px-6 sticky top-0 z-10">
+            <div class="flex items-center space-x-3">
+                <h2 class="text-lg font-medium text-text-primary">Chat Interface</h2>
+                <span class="bg-neon-cyan/20 text-bright-pink text-xs px-2 py-1 rounded-pixel border-thin border-neon-cyan/40 font-medium">Active</span>
+            </div>
+            
+            <div class="flex items-center space-x-2">
+                <div
+                    id="drift-avatar"
+                    x-data="{ avatar: '/interface/avatars/default/default.png' }"
+                    x-init="$watch('avatar', value => {
+        $el.querySelector('img').src = value;
+      })"
+                    class="w-8 h-8 bg-surface-card rounded-full shadow-lg border-2 border-electric-blue/30 transition-all"
+                >
+                    <img :src="avatar" alt="Drift Avatar" class="rounded-full w-full h-full object-cover">
+                </div>
+            </div>
+        </div>
 
-            @if (!empty($commandHistory))
-                <div class="mt-4 bg-zinc-900 p-3 rounded shadow-inner">
-                    <div class="flex flex-wrap gap-2">
+        <!-- Row 2: Chat Content -->
+        <div class="flex-1 p-6 overflow-y-auto space-y-4" id="chat-output">
+            <!-- Chat Messages -->
+            @foreach ($chatMessages as $entry)
+                <x-chat-message :type="$entry['type'] ?? 'user'">
+                    <x-chat-markdown :fragment="null">
+                        {{ $entry['message'] }}
+                    </x-chat-markdown>
+                </x-chat-message>
+            @endforeach
+
+            <!-- Todos Section -->
+            @if (!empty($recalledTodos))
+                @php
+                    $todoFragments = $this->getTodoFragments();
+                @endphp
+                
+                <div class="pixel-card pixel-card-cyan p-4 glow-cyan">
+                    <h2 class="text-lg font-semibold text-neon-cyan mb-3">📋 Todos ({{ $todoFragments->count() }})</h2>
+                    <div class="space-y-2">
+                        @foreach ($todoFragments as $fragment)
+                            <div wire:key="todo-{{ $fragment->id }}" class="bg-surface-elevated rounded-pixel p-2 pixel-card border-thin border-neon-cyan/30">
+                                <livewire:todo-item :fragment="$fragment" :key="'todo-'.$fragment->id" />
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        </div>
+
+        <!-- Row 3: Input Area -->
+        <div class="bg-surface-2 border-t border-thin border-hot-pink/30">                
+            <!-- Chat Input -->
+            <form id="chat-form" x-data wire:submit.prevent="handleInput" class="p-4">
+                <div class="flex space-x-3">
+                    <div class="flex-1">
+                        <textarea 
+                            x-data
+                            wire:model.defer="input"
+                            wire:keydown.enter.prevent="
+                                $el.value = '';
+                                $nextTick(() => {
+                                    document.getElementById('chat-form')?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+                                });
+                            "
+                            class="w-full p-3 border-thin border-hot-pink/30 rounded-pixel resize-none focus:ring-2 focus:ring-hot-pink focus:border-hot-pink pixel-card bg-surface-card text-text-primary" 
+                            rows="2" 
+                            placeholder="Type your message..."
+                        ></textarea>
+                    </div>
+                    <button type="submit" class="px-4 py-2 bg-hot-pink text-white rounded-pixel hover:bg-hot-pink/90 transition-colors self-center pixel-card glow-pink">
+                        Send
+                    </button>
+                </div>
+                
+                <!-- Command History -->
+                @if (!empty($commandHistory))
+                    <div class="mt-3 flex flex-wrap gap-2">
                         @foreach (array_reverse(array_slice($commandHistory, -4)) as $cmd)
                             <button
+                                type="button"
                                 wire:click="injectCommand('{{ addslashes($cmd) }}')"
-                                class="text-xs bg-zinc-800 hover:bg-zinc-700 text-gray-300 rounded px-2 py-1"
+                                class="text-xs bg-surface-card hover:bg-surface-elevated text-text-secondary rounded-pixel px-2 py-1 border-thin border-electric-blue/30 pixel-card glow-blue"
                             >
                                 {{ $cmd }}
                             </button>
                         @endforeach
                     </div>
-                </div>
-            @endif
-
-            <div class="mt-4">
-                <button
-                    x-data
-                    x-on:click="$dispatch('open-command-palette')"
-                    class="text-sm bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-                >
-                    ➕ Commands
-                </button>
-            </div>
-
-
-
-        </form>
-
-
+                @endif
+            </form>
+        </div>
     </div>
 
+    <!-- Right Column: Widgets & Search -->
+    <div class="w-80 bg-surface-2 border-l border-thin border-electric-blue/30 flex flex-col">
+        <!-- Widgets Section -->
+        <div class="flex-1 p-4 overflow-y-auto">
+            <h3 class="text-sm font-medium text-text-secondary mb-4">Widgets</h3>
+            
+            <!-- System Widgets -->
+            <div class="space-y-4 mb-6">
+                <!-- Stats Widget -->
+                <div class="pixel-card pixel-card-pink p-4 glow-pink">
+                    <h4 class="text-sm font-medium text-hot-pink mb-3">Today's Activity</h4>
+                    <div class="space-y-2">
+                        <div class="flex justify-between items-center">
+                            <span class="text-xs text-text-muted">Messages</span>
+                            <span class="text-sm font-medium text-hot-pink">{{ count($chatMessages) }}</span>
+                        </div>
+                        <div class="flex justify-between items-center">
+                            <span class="text-xs text-text-muted">Commands</span>
+                            <span class="text-sm font-medium text-electric-blue">{{ count($commandHistory) }}</span>
+                        </div>
+                        @if (!empty($recalledTodos))
+                            <div class="flex justify-between items-center">
+                                <span class="text-xs text-text-muted">Todos</span>
+                                <span class="text-sm font-medium text-neon-cyan">{{ $this->getTodoFragments()->count() }}</span>
+                            </div>
+                        @endif
+                    </div>
+                </div>
 
+                <!-- Quick Actions Widget -->
+                <div class="pixel-card pixel-card-blue p-4 glow-blue">
+                    <h4 class="text-sm font-medium text-electric-blue mb-3">Quick Actions</h4>
+                    <div class="grid grid-cols-2 gap-2">
+                        <button class="bg-surface-card p-2 rounded-pixel text-xs text-text-secondary hover:bg-hot-pink/20 border-thin border-hot-pink/40 pixel-card glow-pink">Export</button>
+                        <button class="bg-surface-card p-2 rounded-pixel text-xs text-text-secondary hover:bg-electric-blue/20 border-thin border-electric-blue/40 pixel-card glow-blue">Search</button>
+                        <button class="bg-surface-card p-2 rounded-pixel text-xs text-text-secondary hover:bg-neon-cyan/20 border-thin border-neon-cyan/40 pixel-card glow-cyan">Filter</button>
+                        <button class="bg-surface-card p-2 rounded-pixel text-xs text-text-secondary hover:bg-deep-purple/20 border-thin border-deep-purple/40 pixel-card">Archive</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Command Palette Modal -->
     <div
         x-data="{ open: false }"
         x-on:open-command-palette.window="open = true"
@@ -122,14 +238,14 @@
         style="display: none;"
         class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
     >
-        <div class="bg-white dark:bg-zinc-900 rounded-lg p-6 w-96 shadow-xl">
-            <h3 class="text-lg font-semibold mb-4 text-center">⚡ Command Palette</h3>
+        <div class="bg-surface-card rounded-pixel p-6 w-96 shadow-xl pixel-card border-thin border-electric-blue/40 glow-blue">
+            <h3 class="text-lg font-semibold mb-4 text-center text-electric-blue">⚡ Command Palette</h3>
             <div class="space-y-2">
                 @foreach (\App\Services\CommandRegistry::all() as $cmd)
                     <button
                         wire:click="injectCommand('/{{ $cmd }} ')"
                         x-on:click="open = false"
-                        class="w-full text-left bg-zinc-800 hover:bg-zinc-700 text-gray-200 rounded px-3 py-2 text-sm"
+                        class="w-full text-left bg-surface-elevated hover:bg-hot-pink/20 text-text-secondary hover:text-text-primary rounded-pixel px-3 py-2 text-sm pixel-card border-thin border-hot-pink/30 glow-pink"
                     >
                         /{{ $cmd }}
                     </button>
@@ -138,60 +254,11 @@
             <div class="mt-4 text-center">
                 <button
                     x-on:click="open = false"
-                    class="text-xs text-gray-400 hover:text-gray-200"
+                    class="text-xs text-text-muted hover:text-text-secondary"
                 >
                     Close
                 </button>
             </div>
         </div>
     </div>
-
-{{--    <!-- Add Pusher -->--}}
-{{--    <script src="https://js.pusher.com/7.2/pusher.min.js"></script>--}}
-
-{{--    <!-- Add Laravel Echo -->--}}
-{{--    <script src="https://cdn.jsdelivr.net/npm/laravel-echo/dist/echo.iife.js"></script>--}}
-
-    <script>
-        // console.log('Initializing Echo...');
-        //
-        // window.Pusher = Pusher;
-        //
-        // const isHttps = window.location.protocol === 'http:';
-        //
-        // window.Echo = new Echo({
-        //     broadcaster: 'pusher',
-        //     key: '1cdf7afdbf274ab9e94bf2cae69839fb',
-        //     wsHost: 'seer.test',
-        //     wsPort: 6001,
-        //     wssPort: 6001,
-        //     forceTLS: true,
-        //     encrypted: true,
-        //     disableStats: true,
-        //     enabledTransports: ['ws'], // ONLY wss
-        // });
-        //
-        // console.log('Subscribing to lens channel...');
-        //
-        // window.Echo.channel('lens.chat')
-        //     .listen('.fragment-processed', (e) => {
-        //         console.log('Fragment Processed Event!', e);
-        //     })
-        //     .listen('.drift-avatar-change', (event) => {
-        //         console.log('DriftSync Avatar Update!', event);
-        //         document.querySelector('#drift-avatar').__x.$data.avatar = event.avatarPath;
-        //     });
-
-    </script>
-
-{{--    <script>--}}
-{{--        window.addEventListener('drift-avatar-change', event => {--}}
-{{--            document.querySelector('#drift-avatar').__x.$data.avatar = event.detail.avatar;--}}
-{{--        });--}}
-{{--    </script>--}}
-
-
-
-</x-filament-panels::page>
-
-
+</div>

--- a/resources/views/layouts/chat-interface.blade.php
+++ b/resources/views/layouts/chat-interface.blade.php
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Seer - Chat Interface</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,container-queries"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'mono': ['JetBrains Mono', 'Monaco', 'Consolas', 'monospace'],
+                    },
+                    colors: {
+                        'hot-pink': '#FF1493',
+                        'electric-blue': '#00BFFF', 
+                        'neon-cyan': '#00FFFF',
+                        'deep-purple': '#4B0082',
+                        'bright-pink': '#FF69B4',
+                        'surface': '#0f1419',
+                        'surface-2': '#1a1f2e',
+                        'surface-card': '#242b3d',
+                        'surface-elevated': '#2d3548',
+                        'text-primary': '#f8fafc',
+                        'text-secondary': '#cbd5e1',
+                        'text-muted': '#94a3b8',
+                    },
+                    borderRadius: {
+                        'pixel': '3px',
+                    },
+                    borderWidth: {
+                        'thin': '0.5px',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        /* Pixelated corner effects inspired by pixel-style.jpg */
+        .pixel-corner {
+            position: relative;
+        }
+        
+        .pixel-corner::before {
+            content: '';
+            position: absolute;
+            top: -1px;
+            left: -1px;
+            right: -1px;
+            bottom: -1px;
+            background: 
+                radial-gradient(circle at 2px 2px, currentColor 1px, transparent 1px),
+                radial-gradient(circle at 2px calc(100% - 2px), currentColor 1px, transparent 1px),
+                radial-gradient(circle at calc(100% - 2px) 2px, currentColor 1px, transparent 1px),
+                radial-gradient(circle at calc(100% - 2px) calc(100% - 2px), currentColor 1px, transparent 1px);
+            background-size: 4px 4px;
+            background-repeat: no-repeat;
+            pointer-events: none;
+            z-index: -1;
+        }
+        
+        .pixel-card {
+            position: relative;
+            border: 0.5px solid rgba(255, 255, 255, 0.1);
+            background: rgba(36, 43, 61, 0.8);
+            border-radius: 3px;
+        }
+        
+        .pixel-card-pink {
+            border-color: #FF1493;
+            background: linear-gradient(135deg, rgba(255, 20, 147, 0.1) 0%, rgba(255, 20, 147, 0.05) 100%);
+        }
+        
+        .pixel-card-blue {
+            border-color: #00BFFF;
+            background: linear-gradient(135deg, rgba(0, 191, 255, 0.1) 0%, rgba(0, 191, 255, 0.05) 100%);
+        }
+        
+        .pixel-card-cyan {
+            border-color: #00FFFF;
+            background: linear-gradient(135deg, rgba(0, 255, 255, 0.1) 0%, rgba(0, 255, 255, 0.05) 100%);
+        }
+        
+        /* Thin border utility */
+        .border-thin {
+            border-width: 0.5px;
+        }
+        
+        /* Hover glow effects */
+        .glow-pink:hover {
+            box-shadow: 0 0 20px rgba(255, 20, 147, 0.4);
+        }
+        
+        .glow-blue:hover {
+            box-shadow: 0 0 20px rgba(0, 191, 255, 0.4);
+        }
+        
+        .glow-cyan:hover {
+            box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+        }
+    </style>
+    
+    @livewireStyles
+</head>
+<body class="h-full bg-surface text-text-primary overflow-hidden">
+    {{ $slot }}
+    
+    @livewireScripts
+    
+    <script>
+        // Auto-scroll chat to bottom
+        document.addEventListener('DOMContentLoaded', function() {
+            const chatContent = document.querySelector('#chat-output');
+            if (chatContent) {
+                chatContent.scrollTop = chatContent.scrollHeight;
+            }
+        });
+
+        // Auto-scroll on new messages (Livewire updates)
+        document.addEventListener('livewire:update', function() {
+            const chatContent = document.querySelector('#chat-output');
+            if (chatContent) {
+                chatContent.scrollTop = chatContent.scrollHeight;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/resources/views/livewire/todo-item.blade.php
+++ b/resources/views/livewire/todo-item.blade.php
@@ -1,15 +1,15 @@
-<div class="flex items-center gap-3 py-1 transition-all duration-300 ease-in-out hover:bg-gray-800 hover:bg-opacity-30 rounded px-2 -mx-2">
+<div class="flex items-center gap-3 py-2 px-3 transition-all duration-300 ease-in-out hover:bg-neon-cyan/10 rounded-pixel">
     <input
         type="checkbox"
         wire:click="toggle"
         @checked(($fragment->state['status'] ?? 'open') === 'complete')
-        class="h-4 w-4 text-green-500 rounded border-gray-300 focus:ring-green-500 transition-all duration-200"
+        class="h-4 w-4 text-neon-cyan accent-neon-cyan rounded border-neon-cyan/30 focus:ring-neon-cyan/50 transition-all duration-200"
     />
-    <span class="transition-all duration-300 ease-in-out {{ ($fragment->state['status'] ?? 'open') === 'complete' ? 'line-through text-gray-400' : 'text-gray-900' }}">
+    <span class="flex-1 transition-all duration-300 ease-in-out {{ ($fragment->state['status'] ?? 'open') === 'complete' ? 'line-through text-text-muted' : 'text-text-primary' }}">
         {{ $fragment->message }}
     </span>
     @if (($fragment->state['status'] ?? 'open') === 'complete' && isset($fragment->state['completed_at']))
-        <span class="text-xs text-gray-600 ml-auto opacity-60 transition-opacity duration-300">
+        <span class="text-xs text-text-muted ml-auto opacity-60 transition-opacity duration-300">
             {{ \Carbon\Carbon::parse($fragment->state['completed_at'])->diffForHumans() }}
         </span>
     @endif


### PR DESCRIPTION
- Replace single-column layout with 4-column design (ribbon, navigation, chat, widgets)
- Add pixel-card styling with hot-pink, electric-blue, and neon-cyan color scheme
- Create new chat-message component for modular message display
- Update todo-item component to match new design system
- Add missing Livewire methods (injectCommand, showSession) to ChatInterface
- Integrate session indicator into navigation sidebar
- Update command palette with modern styling
- Create custom layout file to handle HTML structure and avoid Livewire conflicts
- Preserve all existing functionality (chat, todos, commands, fragments)

🤖 Generated with [Claude Code](https://claude.ai/code)