### PR TITLE
feat: add persistent chat sessions with history navigation

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Build extends Model {}

--- a/app/Models/ChatSession.php
+++ b/app/Models/ChatSession.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class ChatSession extends Model
+{
+    protected $fillable = [
+        'title',
+        'summary',
+        'messages',
+        'metadata',
+        'message_count',
+        'last_activity_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'messages' => 'array',
+        'metadata' => 'array',
+        'last_activity_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (ChatSession $chatSession) {
+            if (empty($chatSession->title)) {
+                $chatSession->title = 'Chat '.now()->format('M j, g:i A');
+            }
+        });
+    }
+
+    public function addMessage(array $message): void
+    {
+        $messages = $this->getAttribute('messages') ?? [];
+        $messages[] = $message;
+
+        // Force Laravel to recognize the array change by using setAttribute
+        $this->setAttribute('messages', $messages);
+        $this->setAttribute('message_count', count($messages));
+        $this->setAttribute('last_activity_at', now());
+        $this->save();
+
+        $this->updateTitleFromMessages();
+    }
+
+    public function updateTitleFromMessages(): void
+    {
+        $messages = $this->getAttribute('messages') ?? [];
+
+        if ($this->message_count > 0 && ! empty($messages)) {
+            // Find the first non-system message to use as title
+            foreach ($messages as $message) {
+                if (isset($message['type']) && $message['type'] !== 'system' && ! empty($message['message'])) {
+                    $title = Str::limit(strip_tags($message['message']), 40);
+                    if (! empty($title)) {
+                        $this->setAttribute('title', $title);
+                        $this->save();
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public function getDisplayTitleAttribute(): string
+    {
+        return $this->title ?: 'Untitled Chat';
+    }
+
+    public function getLastMessagePreviewAttribute(): string
+    {
+        $messages = $this->getAttribute('messages') ?? [];
+
+        if (empty($messages)) {
+            return 'No messages';
+        }
+
+        $lastMessage = end($messages);
+
+        return Str::limit(strip_tags($lastMessage['message'] ?? ''), 50);
+    }
+
+    public function scopeRecent($query, int $limit = 10)
+    {
+        return $query->where('is_active', true)
+            ->orderBy('last_activity_at', 'desc')
+            ->orderBy('updated_at', 'desc')
+            ->limit($limit);
+    }
+}

--- a/database/migrations/2025_08_24_041146_create_chat_sessions_table.php
+++ b/database/migrations/2025_08_24_041146_create_chat_sessions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chat_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->text('summary')->nullable();
+            $table->json('messages')->nullable(); // Store chat messages as JSON
+            $table->json('metadata')->nullable(); // Store session info, current session data, etc.
+            $table->integer('message_count')->default(0);
+            $table->timestamp('last_activity_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index('last_activity_at');
+            $table->index('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_sessions');
+    }
+};

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -58,24 +58,51 @@
         </div>
         @endif
 
-        <!-- Chat History Placeholder -->
+        <!-- Chat History -->
         <div class="flex-1 p-4 overflow-y-auto">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-sm font-medium text-text-secondary">Recent Chats</h3>
-                <button class="text-xs text-text-muted hover:text-text-secondary">View All</button>
+                <button wire:click="startNewChat" class="text-xs bg-electric-blue/20 hover:bg-electric-blue/30 text-electric-blue px-2 py-1 rounded-pixel border border-electric-blue/40 transition-colors pixel-card glow-blue">
+                    ✨ New Chat
+                </button>
             </div>
             
             <div class="space-y-2">
-                <!-- Current Chat Item -->
-                <div class="pixel-card pixel-card-pink p-3 bg-hot-pink/20 border-hot-pink/60 glow-pink">
-                    <div class="flex items-start justify-between">
-                        <div class="flex-1">
-                            <div class="text-sm font-medium text-text-primary">Current Chat</div>
-                            <div class="text-xs text-text-muted mt-1">{{ count($chatMessages) }} messages</div>
+                @if (!empty($recentChatSessions))
+                    @foreach ($recentChatSessions as $session)
+                        <div 
+                            wire:click="switchToChat({{ $session['id'] }})"
+                            class="pixel-card p-3 cursor-pointer transition-all
+                                {{ $session['id'] === $currentChatSessionId 
+                                    ? 'pixel-card-pink bg-hot-pink/20 border-hot-pink/60 glow-pink' 
+                                    : 'pixel-card-blue bg-electric-blue/10 border-electric-blue/30 hover:bg-electric-blue/20 hover:border-electric-blue/50' 
+                                }}"
+                        >
+                            <div class="flex items-start justify-between">
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-sm font-medium {{ $session['id'] === $currentChatSessionId ? 'text-text-primary' : 'text-text-secondary' }} truncate">
+                                        {{ $session['title'] }}
+                                    </div>
+                                    <div class="text-xs text-text-muted mt-1">
+                                        {{ $session['message_count'] }} messages
+                                    </div>
+                                    @if (!empty($session['preview']))
+                                        <div class="text-xs text-text-muted mt-1 truncate">
+                                            {{ $session['preview'] }}
+                                        </div>
+                                    @endif
+                                </div>
+                                <div class="text-xs {{ $session['id'] === $currentChatSessionId ? 'text-hot-pink' : 'text-electric-blue' }} ml-2 font-medium flex-shrink-0">
+                                    {{ $session['id'] === $currentChatSessionId ? 'Active' : $session['last_activity'] }}
+                                </div>
+                            </div>
                         </div>
-                        <div class="text-xs text-hot-pink ml-2 font-medium">Now</div>
+                    @endforeach
+                @else
+                    <div class="text-center text-text-muted text-xs py-4">
+                        No recent chats
                     </div>
-                </div>
+                @endif
             </div>
         </div>
 
@@ -121,7 +148,7 @@
                 <x-chat-message 
                     :type="$entry['type'] ?? 'user'"
                     :fragmentId="$entry['id'] ?? null"
-                    :timestamp="isset($entry['created_at']) ? $entry['created_at']->diffForHumans() : 'Just now'"
+                    :timestamp="$this->formatTimestamp($entry['created_at'] ?? null)"
                 >
                     <x-chat-markdown :fragment="null">
                         {{ $entry['message'] }}


### PR DESCRIPTION
- Create ChatSession model with message persistence and metadata storage
- Add chat history sidebar with recent sessions display
- Implement New Chat button functionality with session switching
- Update ChatInterface to auto-save messages and maintain state
- Add proper session management with title generation from first message
- Style chat history with pixel-card design matching the design system
- Support switching between multiple chat sessions seamlessly
- Persist current session data, recalled todos, and command history
- Add message count and last activity tracking for each session
- Generate smart titles from chat content automatically

Technical improvements:
- Fix Laravel JSON casting issues using getAttribute/setAttribute methods
- Add robust timestamp formatting with formatTimestamp() helper
- Handle mixed timestamp formats (Carbon instances and ISO strings)
- Resolve "indirect modification of overloaded property" warnings
- Add comprehensive error handling for malformed timestamps

🤖 Generated with [Claude Code](https://claude.ai/code)