### PR TITLE
refactor: update chat interface to use search-result-card component

### DIFF
--- a/app/Filament/Resources/FragmentResource/Pages/ChatInterface.php
+++ b/app/Filament/Resources/FragmentResource/Pages/ChatInterface.php
@@ -295,7 +295,10 @@ class ChatInterface extends Page
 
             $this->chatMessages[] = [
                 'id' => $fragment->id,
-                'type' => $fragment->type?->value ?? 'log',
+                'type' => [
+                    'value' => $fragment->type?->value ?? 'log',
+                    'label' => $fragment->type?->label ?? ucfirst($fragment->type?->value ?? 'log'),
+                ],
                 'type_id' => $fragment->type_id,
                 'message' => $fragment->message,
                 'created_at' => $fragment->created_at,
@@ -903,7 +906,10 @@ class ChatInterface extends Page
             // Add back to chat messages
             $this->chatMessages[] = [
                 'id' => $restoredFragment->id,
-                'type' => $restoredFragment->type,
+                'type' => [
+                    'value' => $restoredFragment->type?->value ?? 'log',
+                    'label' => $restoredFragment->type?->label ?? ucfirst($restoredFragment->type?->value ?? 'log'),
+                ],
                 'message' => $restoredFragment->message,
                 'created_at' => $restoredFragment->created_at,
             ];

--- a/resources/views/components/search-result-card.blade.php
+++ b/resources/views/components/search-result-card.blade.php
@@ -1,6 +1,6 @@
 @props([
-    'fragment', 
-    'showActions' => true, 
+    'fragment',
+    'showActions' => true,
     'showTimestamp' => true,
     'showScore' => false,
     'compact' => false,
@@ -13,19 +13,26 @@
     $message = is_array($fragment) ? ($fragment['message'] ?? '') : ($fragment->message ?? '');
     $createdAt = is_array($fragment) ? ($fragment['created_at'] ?? null) : ($fragment->created_at ?? null);
     $score = is_array($fragment) ? ($fragment['score'] ?? 0) : 0;
-    
-    // Handle type display - prefer 'name' over 'value' for better UX
+
+    // Handle type display - use 'label' for human-readable names
     if (is_array($fragment)) {
-        $typeName = $fragment['type']['name'] ?? ucfirst($fragment['type']['value'] ?? 'fragment');
-        $typeValue = $fragment['type']['value'] ?? 'fragment';
+        // Type could be an array with label/value, or just a string
+        if (is_array($fragment['type'] ?? null)) {
+            $typeName = $fragment['type']['label'] ?? ucfirst($fragment['type']['value'] ?? 'fragment');
+            $typeValue = $fragment['type']['value'] ?? 'fragment';
+        } else {
+            // Type is just a string value
+            $typeValue = $fragment['type'] ?? 'fragment';
+            $typeName = ucfirst($typeValue);
+        }
     } else {
         $typeName = $fragment->type?->label ?? ucfirst($fragment->type?->value ?? 'fragment');
         $typeValue = $fragment->type?->value ?? 'fragment';
     }
 @endphp
 
-<div 
-    class="group transition-colors duration-200 rounded-md {{ $compact ? 'py-2 px-3' : 'py-3 px-4' }} {{ $highlight ? 'bg-electric-blue/10 border border-electric-blue/30' : 'bg-gray-900/60 hover:bg-gray-900/40' }} relative"
+<div
+    class="group transition-colors duration-200 {{ $highlight ? 'bg-electric-blue/10 border border-electric-blue/30 rounded-lg p-3' : 'bg-gray-800 border border-electric-blue/20 rounded-lg p-3' }} relative"
     @if($fragmentId) data-fragment-id="{{ $fragmentId }}" @endif
 >
     <div class="flex items-start justify-between">
@@ -33,11 +40,11 @@
             {{-- Type Display --}}
             <div class="flex items-center justify-between mb-2">
                 <div class="text-sm font-medium">
-                    <span class="text-white">Type:</span> 
+                    <span class="text-white">Type:</span>
                     <span class="text-electric-blue">{{ $typeName }}</span>
                 </div>
             </div>
-            
+
             {{-- Message Content --}}
             <div class="prose prose-sm dark:prose-invert max-w-none text-text-primary">
                 <x-chat-markdown :fragment="null">
@@ -45,7 +52,7 @@
                 </x-chat-markdown>
             </div>
         </div>
-        
+
         {{-- Right Side Actions and Info --}}
         <div class="absolute top-3 right-3 flex flex-col items-end space-y-2">
             {{-- Date (moved above icons as requested) --}}
@@ -54,36 +61,33 @@
                     {{ \Carbon\Carbon::parse($createdAt)->format('M j, g:i A') }}
                 </div>
             @endif
-            
+
             {{-- Action Buttons (20% smaller icons) --}}
             @if($showActions && $fragmentId && is_numeric($fragmentId) && $fragmentId > 0)
-                <div class="flex items-center space-x-2">
-                    <!-- Copy & Delete Buttons - Only show on hover -->
-                    <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                        <!-- Copy Button -->
-                        <button 
-                            onclick="copyChatMessage(this)" 
-                            class="p-1.5 bg-gray-700 hover:bg-neon-cyan/20 text-gray-400 hover:text-neon-cyan rounded border border-gray-600 hover:border-neon-cyan/40 hover:shadow-sm hover:shadow-neon-cyan/20 transition-all"
-                            title="Copy message"
-                        >
-                            <x-heroicon-o-document-duplicate class="w-3.5 h-3.5"/>
-                        </button>
-                        
-                        <!-- Delete Button -->
-                        <button 
-                            wire:click="deleteFragment({{ $fragmentId }})" 
-                            class="p-1.5 bg-gray-700 hover:bg-hot-pink/20 text-gray-400 hover:text-hot-pink rounded border border-gray-600 hover:border-hot-pink/40 hover:shadow-sm hover:shadow-hot-pink/20 transition-all"
-                            title="Delete message"
-                            onclick="event.stopPropagation();"
-                        >
-                            <x-heroicon-o-trash class="w-3.5 h-3.5"/>
-                        </button>
-                    </div>
-                    
-                    <!-- Bookmark Button - Independent visibility -->
-                    <button 
+                <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    <!-- Copy Button -->
+                    <button
+                        onclick="copyChatMessage(this)"
+                        class="p-1.5 bg-gray-700 hover:bg-neon-cyan/20 text-gray-400 hover:text-neon-cyan rounded border border-gray-600 hover:border-neon-cyan/40 hover:shadow-sm hover:shadow-neon-cyan/20 transition-all"
+                        title="Copy message"
+                    >
+                        <x-heroicon-o-document-duplicate class="w-3.5 h-3.5"/>
+                    </button>
+
+                    <!-- Delete Button -->
+                    <button
+                        wire:click="deleteFragment({{ $fragmentId }})"
+                        class="p-1.5 bg-gray-700 hover:bg-hot-pink/20 text-gray-400 hover:text-hot-pink rounded border border-gray-600 hover:border-hot-pink/40 hover:shadow-sm hover:shadow-hot-pink/20 transition-all"
+                        title="Delete message"
+                        onclick="event.stopPropagation();"
+                    >
+                        <x-heroicon-o-trash class="w-3.5 h-3.5"/>
+                    </button>
+
+                    <!-- Bookmark Button -->
+                    <button
                         @click="window.toggleBookmark && window.toggleBookmark({{ $fragmentId }}, $el)"
-                        class="p-1.5 bg-gray-700 hover:bg-hot-pink/20 rounded border border-gray-600 hover:border-hot-pink/40 hover:shadow-sm hover:shadow-hot-pink/20 transition-all opacity-0 group-hover:opacity-100"
+                        class="p-1.5 bg-gray-700 hover:bg-hot-pink/20 rounded border border-gray-600 hover:border-hot-pink/40 hover:shadow-sm hover:shadow-hot-pink/20 transition-all"
                         :class="bookmarked ? 'text-hot-pink border-hot-pink/40 !opacity-100' : 'text-gray-400 hover:text-hot-pink'"
                         title="Toggle bookmark"
                         data-fragment-id="{{ $fragmentId }}"
@@ -97,7 +101,7 @@
             @endif
         </div>
     </div>
-    
+
     {{-- Score Display (moved to bottom right as requested) --}}
     @if($showScore && $score > 0)
         <div class="absolute bottom-2 right-3 text-xs text-electric-blue/70 bg-electric-blue/10 px-2 py-0.5 rounded">

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -450,15 +450,12 @@
                         'message' => $entry['message']
                     ])
                 @else
-                    <x-chat-message
-                        :type="$entry['type'] ?? 'user'"
-                        :fragmentId="$entry['id'] ?? null"
-                        :timestamp="$this->formatTimestamp($entry['created_at'] ?? null)"
-                    >
-                        <x-chat-markdown :fragment="null">
-                            {{ $entry['message'] }}
-                        </x-chat-markdown>
-                    </x-chat-message>
+                    <x-search-result-card
+                        :fragment="$entry"
+                        :showTimestamp="true"
+                        :showScore="false"
+                        :showActions="true"
+                    />
                 @endif
             @endforeach
 

--- a/resources/views/livewire/command-result.blade.php
+++ b/resources/views/livewire/command-result.blade.php
@@ -5,8 +5,8 @@
         <h3 class="text-sm font-medium text-electric-blue capitalize">
             {{ ucfirst(str_replace('_', ' ', $type ?? 'command')) }} Result
         </h3>
-        <button 
-            wire:click="exitCommandMode()" 
+        <button
+            wire:click="exitCommandMode()"
             class="text-xs text-text-muted hover:text-electric-blue transition-colors"
             title="Exit command mode"
         >
@@ -72,9 +72,10 @@
             @if (isset($data['action']) && $data['action'] === 'show' && isset($data['fragments']) && count($data['fragments']) > 0)
                 <div class="space-y-3">
                     @foreach ($data['fragments'] as $fragment)
-                        <x-fragment-card 
-                            :fragment="$fragment" 
+                        <x-search-result-card
+                            :fragment="$fragment"
                             :show-timestamp="true"
+                            :show-score="false"
                             :highlight="true"
                         />
                     @endforeach
@@ -143,8 +144,8 @@
             @if (isset($data['fragments']) && count($data['fragments']) > 0)
                 <div class="space-y-3">
                     @foreach ($data['fragments'] as $fragment)
-                        <x-search-result-card 
-                            :fragment="$fragment" 
+                        <x-search-result-card
+                            :fragment="$fragment"
                             :show-timestamp="true"
                             :show-score="true"
                             :highlight="true"


### PR DESCRIPTION
- Replace x-chat-message with x-search-result-card for consistent UI
- Update search-result-card styling to match recall display (gray background with electric blue border)
- Fix fragment type display to properly show type labels instead of "Fragment"
- Normalize icon spacing in action buttons for better visual consistency
- Pass type data as object with label/value from ChatInterface

🤖 Generated with [Claude Code](https://claude.ai/code)