### PR TITLE
feat: comprehensive todo command system and section-specific help

### DIFF
--- a/app/Actions/Commands/HelpCommand.php
+++ b/app/Actions/Commands/HelpCommand.php
@@ -10,24 +10,110 @@ class HelpCommand implements HandlesCommand
 {
     public function handle(CommandRequest $command): CommandResponse
     {
-        $message = <<<MARKDOWN
-### Commands Cheat Sheet
+        $section = $command->arguments['identifier'] ?? '';
+        
+        // Define all sections
+        $sections = [
+            'recall' => $this->getRecallSection(),
+            'bookmark' => $this->getBookmarkSection(),  
+            'fragment' => $this->getFragmentSection(),
+            'todo' => $this->getTodoSection(),
+            'search' => $this->getSearchSection(),
+            'session' => $this->getSessionSection(),
+            'tools' => $this->getToolsSection(),
+        ];
+        
+        // Handle aliases
+        if ($section === 'sessions') {
+            $section = 'session';
+        }
+        
+        // If specific section requested, return only that section
+        if (!empty($section) && isset($sections[$section])) {
+            $message = "# {$this->getSectionTitle($section)}\n\n" . $sections[$section];
+        } else {
+            // Return all sections
+            $message = "# Commands Cheat Sheet\n\nHere are the commands you can use in the chat:\n\n";
+            foreach ($sections as $key => $content) {
+                $message .= "## {$this->getSectionTitle($key)}\n{$content}\n\n";
+            }
+            $message .= "---\nAll fragments are stored and processed. Bookmarks and sessions give you quick access to curated memories and grouped ideas.";
+        }
 
-Here are the commands you can use in the chat:
-
-#### 🔍 Recall & Memory
+        return new CommandResponse(
+            type: 'help',
+            shouldOpenPanel: true,
+            panelData: [
+                'message' => $message,
+            ],
+        );
+    }
+    
+    private function getSectionTitle(string $section): string
+    {
+        return match($section) {
+            'recall' => 'Recall Commands',
+            'bookmark' => 'Bookmark Commands',
+            'fragment' => 'Fragment Commands', 
+            'todo' => 'Todo Management',
+            'search' => 'Search Commands',
+            'session' => 'Sessions',
+            'tools' => 'Chat Tools',
+            default => 'Commands',
+        };
+    }
+    
+    private function getRecallSection(): string
+    {
+        return <<<MARKDOWN
 - `/recall type:todo limit:5` – Recall recent fragments by type
 - `/recall session {hint}` – Recall all fragments from a saved session (coming soon 🚀)
+MARKDOWN;
+    }
+    
+    private function getBookmarkSection(): string
+    {
+        return <<<MARKDOWN
 - `/bookmark` – Bookmark the most recent fragment (or all from chaos)
 - `/bookmark list` – List saved bookmarks
 - `/bookmark show {hint}` – Replay a bookmark in the chat
 - `/bookmark forget {hint}` – Delete a saved bookmark
-
-#### 🔁 Fragments
+MARKDOWN;
+    }
+    
+    private function getFragmentSection(): string
+    {
+        return <<<MARKDOWN
 - `/frag This is something worth remembering` – Log a fragment
 - `/chaos This contains multiple items. Do X. Also do Y.` – Split and log a chaos fragment
-
-#### 🧠 Sessions
+- `/todo Fix the login bug #urgent` – Create a new todo fragment with tags
+MARKDOWN;
+    }
+    
+    private function getTodoSection(): string
+    {
+        return <<<MARKDOWN
+- `/todo` – List 25 open todos (newest first)
+- `/todo list` – List 25 open todos (explicit)
+- `/todo list status:completed` – List completed todos
+- `/todo list #urgent limit:5` – List 5 urgent todos
+- `/todo list search:client` – Search todos for "client"
+- `/todo complete:1` – Mark first todo complete
+- `/todo complete:"login bug"` – Mark matching todo complete
+MARKDOWN;
+    }
+    
+    private function getSearchSection(): string
+    {
+        return <<<MARKDOWN
+- `/search your query here` – Search all fragments with hybrid search
+- `/s your query here` – Shorthand for search
+MARKDOWN;
+    }
+    
+    private function getSessionSection(): string
+    {
+        return <<<MARKDOWN
 - `/session vault:work type:meeting Project Sync #weekly` – Start a scoped session for all new fragments
 - `/session show` – Display current active session details
 - `/session end` – End the current session and return to normal logging
@@ -43,21 +129,14 @@ Example:
 - Tags: `shorts`
 - Identifier: `Ideas for Short Stories`
 - Session grouping key for easy recall later.
-
-#### 🧹 Chat Tools
+MARKDOWN;
+    }
+    
+    private function getToolsSection(): string
+    {
+        return <<<MARKDOWN
 - `/clear` – Clear the current chat view
 - `/help` – Show this help message
-
----
-All fragments are stored and processed. Bookmarks and sessions give you quick access to curated memories and grouped ideas.
 MARKDOWN;
-
-        return new CommandResponse(
-            type: 'help',
-            shouldOpenPanel: true,
-            panelData: [
-                'message' => $message,
-            ],
-        );
     }
 }

--- a/app/Actions/Commands/TodoCommand.php
+++ b/app/Actions/Commands/TodoCommand.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Actions\Commands;
+
+use App\Contracts\HandlesCommand;
+use App\DTOs\CommandRequest;
+use App\DTOs\CommandResponse;
+use App\Models\Fragment;
+use Illuminate\Support\Facades\Log;
+
+class TodoCommand implements HandlesCommand
+{
+    public function handle(CommandRequest $command): CommandResponse
+    {
+        // Check if this is a subcommand (list, complete) or todo creation
+        $identifier = $command->arguments['identifier'] ?? '';
+
+        // Handle subcommands
+        if ($identifier === 'list') {
+            return $this->handleList($command);
+        }
+
+        // Handle completion actions
+        $complete = $command->arguments['complete'] ?? null;
+        if ($complete !== null) {
+            return $this->handleCompletion($complete);
+        }
+
+        // If no subcommand and no structured arguments, treat as todo creation
+        if (empty($command->arguments['status']) &&
+            empty($command->arguments['search']) &&
+            empty($command->arguments['limit']) &&
+            ! empty($identifier)) {
+            return $this->handleCreate($command);
+        }
+
+        // Default to list behavior for backwards compatibility
+        return $this->handleList($command);
+    }
+
+    private function handleCreate(CommandRequest $command): CommandResponse
+    {
+        $message = $command->arguments['identifier'] ?? '';
+        $tags = $command->arguments['tags'] ?? [];
+
+        if (empty($message)) {
+            return new CommandResponse(
+                type: 'system',
+                shouldShowErrorToast: true,
+                message: 'Please provide a message for the todo. Example: `/todo Fix the login bug #urgent`',
+            );
+        }
+
+        // Get the todo type ID
+        $todoType = \App\Models\Type::where('value', 'todo')->first();
+        if (! $todoType) {
+            return new CommandResponse(
+                type: 'system',
+                shouldShowErrorToast: true,
+                message: 'Todo type not found in database. Please contact administrator.',
+            );
+        }
+
+        // Create the fragment
+        $fragment = Fragment::create([
+            'type' => 'todo',
+            'type_id' => $todoType->id,
+            'message' => $message,
+            'tags' => $tags,
+            'state' => ['status' => 'open'],
+            'created_at' => now(),
+        ]);
+
+        $tagText = ! empty($tags) ? ' with tags: #'.implode(', #', $tags) : '';
+
+        return new CommandResponse(
+            type: 'system',
+            shouldShowSuccessToast: true,
+            message: '✅ Created todo: '.$this->truncate($message, 50).$tagText,
+            toastData: [
+                'title' => 'Todo Added',
+                'message' => $this->truncate($message, 50).$tagText,
+                'fragmentType' => 'todo',
+                'fragmentId' => $fragment->id,
+            ],
+        );
+    }
+
+    private function handleList(CommandRequest $command): CommandResponse
+    {
+        // Parse arguments for list functionality
+        $status = $command->arguments['status'] ?? 'open';
+        $searchTerm = $command->arguments['search'] ?? null;
+        $tags = $command->arguments['tags'] ?? [];
+        $limit = (int) ($command->arguments['limit'] ?? 25);
+
+        // Build query for todos using scopes
+        $query = Fragment::todosByStatus($status)
+            ->with('type');
+
+        // Apply tag filters
+        if (! empty($tags)) {
+            foreach ($tags as $tag) {
+                $query->whereJsonContains('tags', $tag);
+            }
+        }
+
+        // Apply search filter
+        if ($searchTerm) {
+            $query->where(function ($q) use ($searchTerm) {
+                $q->where('message', 'LIKE', "%{$searchTerm}%")
+                    ->orWhere('title', 'LIKE', "%{$searchTerm}%");
+            });
+        }
+
+        // Apply ordering and limit
+        if ($status === 'completed') {
+            // For completed todos, order by completion date
+            $query->orderByRaw("(state::jsonb->>'completed_at') DESC");
+        } else {
+            // For open todos, order by creation date (newest first)
+            $query->latest();
+        }
+
+        $results = $query->limit($limit)->get();
+
+        if ($results->isEmpty()) {
+            return $this->emptyResponse($status, $searchTerm, $tags);
+        }
+
+        return new CommandResponse(
+            type: 'recall',
+            shouldOpenPanel: true,
+            panelData: [
+                'type' => 'todo',
+                'status' => $status,
+                'search' => $searchTerm,
+                'tags' => $tags,
+                'fragments' => $results->toArray(),
+                'message' => $this->buildResultMessage($status, $results->count(), $searchTerm, $tags),
+            ],
+        );
+    }
+
+    private function handleCompletion($complete): CommandResponse
+    {
+        try {
+            if (is_numeric($complete)) {
+                // Position-based completion
+                return $this->completeByPosition((int) $complete);
+            } else {
+                // Keyword-based completion
+                return $this->completeByKeyword($complete);
+            }
+        } catch (\Exception $e) {
+            Log::error('Todo completion failed', [
+                'complete' => $complete,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new CommandResponse(
+                type: 'system',
+                shouldShowErrorToast: true,
+                message: "Failed to complete todo: {$e->getMessage()}",
+            );
+        }
+    }
+
+    private function completeByPosition(int $position): CommandResponse
+    {
+        // Get open todos in the same order as displayed
+        $todos = Fragment::openTodos()
+            ->latest()
+            ->get();
+
+        if ($position < 1 || $position > $todos->count()) {
+            return new CommandResponse(
+                type: 'system',
+                shouldShowErrorToast: true,
+                message: "Invalid position {$position}. Available todos: 1-{$todos->count()}",
+            );
+        }
+
+        $todo = $todos->skip($position - 1)->first();
+        $this->markComplete($todo);
+
+        return new CommandResponse(
+            type: 'system',
+            shouldShowSuccessToast: true,
+            message: "✅ Completed todo #{$position}: ".$this->truncate($todo->message, 50),
+        );
+    }
+
+    private function completeByKeyword(string $keyword): CommandResponse
+    {
+        // Search for matching open todo
+        $todo = Fragment::openTodos()
+            ->where(function ($q) use ($keyword) {
+                $q->where('message', 'LIKE', "%{$keyword}%")
+                    ->orWhere('title', 'LIKE', "%{$keyword}%");
+            })
+            ->first();
+
+        if (! $todo) {
+            return new CommandResponse(
+                type: 'system',
+                shouldShowErrorToast: true,
+                message: "No open todo found matching: {$keyword}",
+            );
+        }
+
+        $this->markComplete($todo);
+
+        return new CommandResponse(
+            type: 'system',
+            shouldShowSuccessToast: true,
+            message: '✅ Completed todo: '.$this->truncate($todo->message, 50),
+        );
+    }
+
+    private function markComplete(Fragment $todo): void
+    {
+        $state = $todo->state ?? [];
+        $state['status'] = 'complete';
+        $state['completed_at'] = now()->toISOString();
+
+        $todo->state = $state;
+        $todo->save();
+    }
+
+    private function emptyResponse(string $status, ?string $searchTerm, array $tags): CommandResponse
+    {
+        $filters = [];
+        if ($status !== 'open') {
+            $filters[] = "status:{$status}";
+        }
+        if ($searchTerm) {
+            $filters[] = "search:{$searchTerm}";
+        }
+        if (! empty($tags)) {
+            $filters[] = '#'.implode(' #', $tags);
+        }
+
+        $filterText = ! empty($filters) ? ' with filters: '.implode(', ', $filters) : '';
+
+        return new CommandResponse(
+            type: 'recall',
+            shouldOpenPanel: true,
+            panelData: [
+                'type' => 'todo',
+                'status' => $status,
+                'search' => $searchTerm,
+                'tags' => $tags,
+                'fragments' => [],
+                'message' => "📝 No todos found{$filterText}",
+            ],
+        );
+    }
+
+    private function buildResultMessage(string $status, int $count, ?string $searchTerm, array $tags): string
+    {
+        $statusText = $status === 'completed' ? 'completed' : 'open';
+        $base = "📝 Found **{$count}** {$statusText} todo".($count !== 1 ? 's' : '');
+
+        $filters = [];
+        if ($searchTerm) {
+            $filters[] = "matching '{$searchTerm}'";
+        }
+        if (! empty($tags)) {
+            $filters[] = 'tagged #'.implode(', #', $tags);
+        }
+
+        return $base.(! empty($filters) ? ' '.implode(' and ', $filters) : '');
+    }
+
+    private function truncate(string $text, int $length): string
+    {
+        return strlen($text) > $length ? substr($text, 0, $length).'...' : $text;
+    }
+}

--- a/app/Services/CommandRegistry.php
+++ b/app/Services/CommandRegistry.php
@@ -10,6 +10,7 @@ use App\Actions\Commands\HelpCommand;
 use App\Actions\Commands\RecallCommand;
 use App\Actions\Commands\SearchCommand;
 use App\Actions\Commands\SessionCommand;
+use App\Actions\Commands\TodoCommand;
 
 class CommandRegistry
 {
@@ -23,13 +24,15 @@ class CommandRegistry
         'chaos' => ChaosCommand::class,
         'search' => SearchCommand::class,
         's' => SearchCommand::class, // alias for search
+        'todo' => TodoCommand::class,
+        't' => TodoCommand::class, // alias for todo
         // 'export' => ExportCommand::class (future)
     ];
 
     public static function find(string $commandName): string
     {
         logger('COMMAND_REGISTRY_LOOKUP', ['commandName' => $commandName]);
-        if (!array_key_exists($commandName, self::$commands)) {
+        if (! array_key_exists($commandName, self::$commands)) {
             throw new \InvalidArgumentException("Command not recognized: {$commandName}");
         }
 
@@ -40,6 +43,4 @@ class CommandRegistry
     {
         return array_keys(self::$commands);
     }
-
-
 }

--- a/config/prism.php
+++ b/config/prism.php
@@ -23,37 +23,37 @@ return [
         'ollama' => [
             'url' => env('OLLAMA_URL', 'http://localhost:11434'),
         ],
-//        'mistral' => [
-//            'api_key' => env('MISTRAL_API_KEY', ''),
-//            'url' => env('MISTRAL_URL', 'https://api.mistral.ai/v1'),
-//        ],
-//        'groq' => [
-//            'api_key' => env('GROQ_API_KEY', ''),
-//            'url' => env('GROQ_URL', 'https://api.groq.com/openai/v1'),
-//        ],
-//        'xai' => [
-//            'api_key' => env('XAI_API_KEY', ''),
-//            'url' => env('XAI_URL', 'https://api.x.ai/v1'),
-//        ],
-//        'gemini' => [
-//            'api_key' => env('GEMINI_API_KEY', ''),
-//            'url' => env('GEMINI_URL', 'https://generativelanguage.googleapis.com/v1beta/models'),
-//        ],
-//        'deepseek' => [
-//            'api_key' => env('DEEPSEEK_API_KEY', ''),
-//            'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com/v1'),
-//        ],
-//        'elevenlabs' => [
-//            'api_key' => env('ELEVENLABS_API_KEY', ''),
-//            'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1/'),
-//        ],
-//        'voyageai' => [
-//            'api_key' => env('VOYAGEAI_API_KEY', ''),
-//            'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
-//        ],
-//        'openrouter' => [
-//            'api_key' => env('OPENROUTER_API_KEY', ''),
-//            'url' => env('OPENROUTER_URL', 'https://openrouter.ai/api/v1'),
-//        ],
+        //        'mistral' => [
+        //            'api_key' => env('MISTRAL_API_KEY', ''),
+        //            'url' => env('MISTRAL_URL', 'https://api.mistral.ai/v1'),
+        //        ],
+        //        'groq' => [
+        //            'api_key' => env('GROQ_API_KEY', ''),
+        //            'url' => env('GROQ_URL', 'https://api.groq.com/openai/v1'),
+        //        ],
+        //        'xai' => [
+        //            'api_key' => env('XAI_API_KEY', ''),
+        //            'url' => env('XAI_URL', 'https://api.x.ai/v1'),
+        //        ],
+        //        'gemini' => [
+        //            'api_key' => env('GEMINI_API_KEY', ''),
+        //            'url' => env('GEMINI_URL', 'https://generativelanguage.googleapis.com/v1beta/models'),
+        //        ],
+        //        'deepseek' => [
+        //            'api_key' => env('DEEPSEEK_API_KEY', ''),
+        //            'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com/v1'),
+        //        ],
+        //        'elevenlabs' => [
+        //            'api_key' => env('ELEVENLABS_API_KEY', ''),
+        //            'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1/'),
+        //        ],
+        //        'voyageai' => [
+        //            'api_key' => env('VOYAGEAI_API_KEY', ''),
+        //            'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
+        //        ],
+        'openrouter' => [
+            'api_key' => env('OPENROUTER_API_KEY', ''),
+            'url' => env('OPENROUTER_BASE', 'https://openrouter.ai/api/v1'),
+        ],
     ],
 ];

--- a/resources/views/components/undo-toast.blade.php
+++ b/resources/views/components/undo-toast.blade.php
@@ -8,6 +8,7 @@
         fragmentId: null,
         objectType: 'fragment',
         messageType: 'delete', // 'delete', 'success', 'error'
+        customTitle: null,
         countdownInterval: null,
         
         display(fragmentId, message, objectType = 'fragment', duration = 60) {
@@ -29,12 +30,13 @@
             }, 1000);
         },
         
-        displaySuccess(message, objectType = 'fragment', duration = 2) {
-            console.log('Undo toast success called with:', { message, objectType, duration });
+        displaySuccess(message, objectType = 'fragment', duration = 2, customTitle = null) {
+            console.log('Undo toast success called with:', { message, objectType, duration, customTitle });
             this.fragmentId = null; // No undo action for success messages
             this.message = message;
             this.objectType = objectType;
             this.messageType = 'success';
+            this.customTitle = customTitle;
             this.timeLeft = duration;
             this.show = true;
             
@@ -73,6 +75,9 @@
             }
             if (!this.fragmentId) {
                 // Success message - no undo action
+                if (this.customTitle) {
+                    return this.customTitle;
+                }
                 return this.objectType === 'chat' ? 'Chat restored' : 'Fragment restored';
             }
             // Delete message - with undo action

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -1493,25 +1493,30 @@
                 }
             });
 
+            // DISABLED: First listener commented out to avoid conflicts
+            /*
             // Listen for success toast events (for /frag and /chaos commands)
             Livewire.on('show-success-toast', function(event) {
-                console.log('Received success toast event:', event);
+                console.log('FIRST success toast listener received:', event);
 
                 let title = event.title || event.detail?.title || 'Success';
                 let message = event.message || event.detail?.message;
                 let fragmentType = event.fragmentType || event.detail?.fragmentType || 'fragment';
                 let fragmentId = event.fragmentId || event.detail?.fragmentId || null;
 
-                console.log('Success toast values:', { title, message, fragmentType, fragmentId });
+                console.log('FIRST listener success toast values:', { title, message, fragmentType, fragmentId });
 
                 if (message) {
                     const toastElement = document.getElementById('success-toast');
                     if (toastElement && toastElement._x_dataStack && toastElement._x_dataStack[0]) {
-                        console.log('Calling display with:', title, message, fragmentType, fragmentId);
+                        console.log('FIRST listener calling display with:', title, message, fragmentType, fragmentId);
                         toastElement._x_dataStack[0].display(title, message, fragmentType, fragmentId, 5);
+                    } else {
+                        console.log('FIRST listener: success-toast element not found or not ready');
                     }
                 }
             });
+            */
 
             // Listen for browser success toast events
             window.addEventListener('show-success-toast', function(event) {
@@ -1537,11 +1542,48 @@
                 }
             });
 
+            // Handle success toasts with custom titles (for todo creation, etc.)
             Livewire.on('show-success-toast', function(data) {
-                // Use the unified undo-toast for success messages
-                const toastElement = document.getElementById('undo-toast');
-                if (toastElement && toastElement._x_dataStack && toastElement._x_dataStack[0]) {
-                    toastElement._x_dataStack[0].displaySuccess(data.message, 'fragment', 2);
+                console.log('SECOND success toast handler received:', data);
+                
+                // Livewire events come as arrays, get the first element
+                const eventData = Array.isArray(data) ? data[0] : data;
+                console.log('Processed event data:', eventData);
+                console.log('Title check:', { title: eventData.title, isCustom: (eventData.title && eventData.title !== 'Success') });
+                
+                // If we have a custom title, use success-toast component
+                if (eventData.title && eventData.title !== 'Success') {
+                    console.log('Attempting to use success-toast for custom title:', eventData.title);
+                    const successToastElement = document.getElementById('success-toast');
+                    console.log('success-toast element found:', !!successToastElement);
+                    
+                    if (successToastElement && successToastElement._x_dataStack && successToastElement._x_dataStack[0]) {
+                        console.log('SUCCESS: Using success-toast for custom title:', eventData.title);
+                        successToastElement._x_dataStack[0].display(
+                            eventData.title, 
+                            eventData.message, 
+                            eventData.fragmentType || 'fragment', 
+                            eventData.fragmentId || null, 
+                            3
+                        );
+                        return;
+                    } else {
+                        console.log('FAILED: success-toast element not ready, _x_dataStack:', successToastElement?._x_dataStack);
+                    }
+                }
+                
+                // Fallback to undo-toast for generic messages (like fragment restored)
+                console.log('FALLBACK: Using undo-toast for message');
+                const undoToastElement = document.getElementById('undo-toast');
+                if (undoToastElement && undoToastElement._x_dataStack && undoToastElement._x_dataStack[0]) {
+                    console.log('undo-toast element ready, displaying success');
+                    undoToastElement._x_dataStack[0].displaySuccess(
+                        eventData.message, 
+                        eventData.fragmentType || 'fragment', 
+                        2
+                    );
+                } else {
+                    console.log('ERROR: undo-toast element not found or not ready');
                 }
             });
 

--- a/resources/views/livewire/command-result.blade.php
+++ b/resources/views/livewire/command-result.blade.php
@@ -26,7 +26,7 @@
         @if ($type === 'recall')
             {{-- Recall Results --}}
             @if (isset($data['fragments']) && count($data['fragments']) > 0)
-                <div class="space-y-3">
+                <div class="space-y-1">
                     @foreach ($data['fragments'] as $fragment)
                         @if (($fragment['type']['value'] ?? '') === 'todo')
                             {{-- Use Livewire TodoItem for todos --}}

--- a/resources/views/livewire/command-result.blade.php
+++ b/resources/views/livewire/command-result.blade.php
@@ -26,6 +26,27 @@
         @if ($type === 'recall')
             {{-- Recall Results --}}
             @if (isset($data['fragments']) && count($data['fragments']) > 0)
+                {{-- Live search for todo results --}}
+                @if (isset($data['type']) && $data['type'] === 'todo')
+                    <div class="mb-4">
+                        <div class="relative">
+                            <input
+                                type="text"
+                                placeholder="Search todos..."
+                                class="w-full px-3 py-2 text-sm bg-surface/50 border border-electric-blue/20 rounded-lg focus:outline-none focus:ring-2 focus:ring-electric-blue/50 focus:border-electric-blue text-text-primary placeholder:text-text-muted"
+                                x-data="{ search: '' }"
+                                x-model="search"
+                                x-on:input.debounce.300ms="@this.call('filterTodos', search)"
+                            />
+                            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+                                <svg class="w-4 h-4 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+
                 <div class="space-y-1">
                     @foreach ($data['fragments'] as $fragment)
                         @if (($fragment['type']['value'] ?? '') === 'todo')

--- a/resources/views/livewire/todo-item.blade.php
+++ b/resources/views/livewire/todo-item.blade.php
@@ -1,4 +1,4 @@
-<div class="flex items-center gap-3 py-2 px-3 transition-all duration-300 ease-in-out hover:bg-neon-cyan/10 rounded-pixel">
+<div class="flex items-center gap-3 py-1 px-3 transition-all duration-300 ease-in-out hover:bg-neon-cyan/10 rounded-pixel">
     <input
         type="checkbox"
         wire:click="toggle"


### PR DESCRIPTION
## Summary
- Implement comprehensive TodoCommand system with dual functionality (create vs list)
- Add section-specific help system with emoji-free headers  
- Fix toast message routing for proper "Todo Added" notifications
- Add live search functionality for todo results
- Ensure PostgreSQL compatibility with proper JSON queries

## Key Features
- **New Todo Creation**: `/todo Fix the login bug #urgent` creates todos with tags
- **Backwards Compatible**: Existing `/todo` and `/todo list` commands still work
- **Section-Specific Help**: `/help recall`, `/help todo`, `/help sessions` etc.
- **Live Todo Search**: Real-time filtering in todo results with debouncing
- **Proper Toast Messages**: Shows "Todo Added" instead of "Fragment Restored!"

## Technical Changes
- Created TodoCommand class with handleCreate() and handleList() methods
- Added PostgreSQL-compatible scopes to Fragment model (openTodos, completedTodos)
- Refactored HelpCommand into modular sections with alias support
- Fixed Livewire event data structure handling (arrays vs objects)
- Added live search input to command-result.blade.php for todo filtering
- Registered TodoCommand with 't' alias in CommandRegistry

## Test Plan
- [ ] Verify `/todo message #tags` creates todos correctly
- [ ] Confirm `/todo` and `/todo list` work as before
- [ ] Test section-specific help commands (`/help recall`, `/help todo`, etc.)
- [ ] Validate live search filtering in todo results
- [ ] Check toast messages show correct titles ("Todo Added" vs "Fragment Restored!")
- [ ] Ensure PostgreSQL JSON queries work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)