### PR TITLE
feat: implement IRC-style channel navigation with join commands

### DIFF
--- a/app/Actions/Commands/ChannelsCommand.php
+++ b/app/Actions/Commands/ChannelsCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Actions\Commands;
+
+use App\Contracts\HandlesCommand;
+use App\DTOs\CommandRequest;
+use App\DTOs\CommandResponse;
+use App\Models\ChatSession;
+
+class ChannelsCommand implements HandlesCommand
+{
+    public function handle(CommandRequest $command): CommandResponse
+    {
+        // Get vault/project context from command
+        $vaultId = $command->arguments['vault_id'] ?? null;
+        $projectId = $command->arguments['project_id'] ?? null;
+        
+        // Get all active chat sessions
+        $channels = ChatSession::searchForAutocomplete('', $vaultId, $projectId, 25);
+        
+        if ($channels->isEmpty()) {
+            return new CommandResponse(
+                type: 'channels-list',
+                shouldOpenPanel: true,
+                panelData: [
+                    'message' => "**No Active Channels**\n\nThere are no active chat channels in the current context.",
+                ]
+            );
+        }
+        
+        // Format channels list
+        $channelsList = $channels->map(function ($session) {
+            $activity = $session->last_activity_at ? $session->last_activity_at->diffForHumans() : 'No activity';
+            return "- `#{$session->short_code}` – {$session->display_name} *(last activity: {$activity})*";
+        })->join("\n");
+        
+        $count = $channels->count();
+        $title = "**Active Channels ({$count})**";
+        $message = "{$title}\n\n{$channelsList}\n\nType `/join #c5` to join a specific channel.";
+        
+        return new CommandResponse(
+            type: 'channels-list',
+            shouldOpenPanel: true,
+            panelData: [
+                'message' => $message,
+                'channels' => $channels->map(function ($session) {
+                    return [
+                        'id' => $session->id,
+                        'short_code' => $session->short_code,
+                        'display_name' => $session->display_name,
+                        'channel_display' => $session->channel_display,
+                        'last_activity' => $session->last_activity_at?->diffForHumans()
+                    ];
+                })->toArray()
+            ]
+        );
+    }
+}

--- a/app/Actions/Commands/HelpCommand.php
+++ b/app/Actions/Commands/HelpCommand.php
@@ -19,6 +19,7 @@ class HelpCommand implements HandlesCommand
             'fragment' => $this->getFragmentSection(),
             'todo' => $this->getTodoSection(),
             'search' => $this->getSearchSection(),
+            'join' => $this->getJoinSection(),
             'session' => $this->getSessionSection(),
             'tools' => $this->getToolsSection(),
         ];
@@ -57,6 +58,7 @@ class HelpCommand implements HandlesCommand
             'fragment' => 'Fragment Commands', 
             'todo' => 'Todo Management',
             'search' => 'Search Commands',
+            'join' => 'Channel Navigation',
             'session' => 'Sessions',
             'tools' => 'Chat Tools',
             default => 'Commands',
@@ -108,6 +110,27 @@ MARKDOWN;
         return <<<MARKDOWN
 - `/search your query here` – Search all fragments with hybrid search
 - `/s your query here` – Shorthand for search
+MARKDOWN;
+    }
+    
+    private function getJoinSection(): string
+    {
+        return <<<MARKDOWN
+- `/join #c5` – Join channel #c5 by short code
+- `/join #custom` – Join channel by custom name  
+- `/join #` – Show all available channels
+- `/join bug` – Search for channels containing "bug"
+- `/j #c1` – Shorthand for join (alias)
+
+**Examples:**
+- `/join #c1` – Switch to channel #c1 (by short code)
+- `/join #ProjectAlpha` – Switch to channel named "ProjectAlpha"
+- `/join project` – Find channels about "project"
+- `/join #` – Browse all active channels
+
+**Related Commands:**
+- `/channels` – List all available channels
+- `/name Custom Name` – Rename current channel
 MARKDOWN;
     }
     

--- a/app/Actions/Commands/JoinCommand.php
+++ b/app/Actions/Commands/JoinCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Actions\Commands;
+
+use App\Contracts\HandlesCommand;
+use App\DTOs\CommandRequest;
+use App\DTOs\CommandResponse;
+use App\Models\ChatSession;
+
+class JoinCommand implements HandlesCommand
+{
+    public function handle(CommandRequest $command): CommandResponse
+    {
+        $identifier = trim($command->arguments['identifier'] ?? '');
+        
+        // Get vault/project context from command
+        $vaultId = $command->arguments['vault_id'] ?? null;
+        $projectId = $command->arguments['project_id'] ?? null;
+        
+        // If no identifier provided, show autocomplete help
+        if (empty($identifier)) {
+            return $this->showAutocompleteHelp();
+        }
+        
+        // Handle autocomplete request (/join #)
+        if ($identifier === '#') {
+            return $this->showAutocompleteResults('', null, $vaultId, $projectId);
+        }
+        
+        // Handle channel navigation (/join #c5 or /join #custom)
+        if (str_starts_with($identifier, '#')) {
+            $channelIdentifier = substr($identifier, 1); // Remove the #
+            return $this->joinByChannelIdentifier($channelIdentifier);
+        }
+        
+        // Handle search query (/join bug)
+        return $this->searchAndJoin($identifier, $vaultId, $projectId);
+    }
+    
+    private function joinByChannelIdentifier(string $identifier): CommandResponse
+    {
+        $chatSession = null;
+        
+        // First, try to find by short code (e.g., "c5" from "#c5")
+        if (preg_match('/^c\d+$/', $identifier)) {
+            $chatSession = ChatSession::findByShortCode($identifier);
+        }
+        
+        // If not found by short code, try to find by custom name (e.g., "custom" from "#custom")
+        if (!$chatSession) {
+            $chatSession = ChatSession::findByCustomName($identifier);
+        }
+        
+        if (!$chatSession) {
+            return new CommandResponse(
+                type: 'join-error',
+                shouldShowErrorToast: true,
+                message: "Channel #{$identifier} not found. Try /join # to see available channels or /channels to list all."
+            );
+        }
+        
+        // Return success response that will trigger chat switching
+        return new CommandResponse(
+            type: 'join-success',
+            shouldOpenPanel: false,
+            shouldShowSuccessToast: true,
+            toastData: [
+                'title' => 'Channel Joined',
+                'message' => "Switched to {$chatSession->channel_display}",
+                'fragmentType' => 'chat',
+                'fragmentId' => null
+            ],
+            data: [
+                'action' => 'switch_chat',
+                'chat_session_id' => $chatSession->id,
+                'channel_name' => $chatSession->channel_display
+            ]
+        );
+    }
+    
+    private function searchAndJoin(string $query, ?int $vaultId = null, ?int $projectId = null): CommandResponse
+    {
+        $results = ChatSession::searchForAutocomplete($query, $vaultId, $projectId, 5);
+        
+        if ($results->isEmpty()) {
+            return new CommandResponse(
+                type: 'join-error',
+                shouldShowErrorToast: true,
+                message: "No channels found matching '{$query}'. Try /join # to see all channels."
+            );
+        }
+        
+        if ($results->count() === 1) {
+            // Single result - join directly
+            $chatSession = $results->first();
+            return new CommandResponse(
+                type: 'join-success',
+                shouldOpenPanel: false,
+                shouldShowSuccessToast: true,
+                toastData: [
+                    'title' => 'Channel Joined',
+                    'message' => "Switched to {$chatSession->channel_display}",
+                    'fragmentType' => 'chat',
+                    'fragmentId' => null
+                ],
+                data: [
+                    'action' => 'switch_chat',
+                    'chat_session_id' => $chatSession->id,
+                    'channel_name' => $chatSession->channel_display
+                ]
+            );
+        }
+        
+        // Multiple results - show selection
+        return $this->showAutocompleteResults($query, $results);
+    }
+    
+    private function showAutocompleteHelp(): CommandResponse
+    {
+        $message = <<<MARKDOWN
+# Join Channel
+
+Usage:
+- `/join #c5` – Join channel #c5 directly
+- `/join #` – Show all available channels
+- `/join bug` – Search for channels containing "bug"
+
+Examples:
+- `/join #c1` – Switch to channel #c1
+- `/join project` – Find channels about "project"
+MARKDOWN;
+
+        return new CommandResponse(
+            type: 'help',
+            shouldOpenPanel: true,
+            panelData: [
+                'message' => $message,
+            ],
+        );
+    }
+    
+    private function showAutocompleteResults(string $query = '', $results = null, ?int $vaultId = null, ?int $projectId = null): CommandResponse
+    {
+        if ($results === null) {
+            $results = ChatSession::searchForAutocomplete($query, $vaultId, $projectId, 10);
+        }
+        
+        if ($results->isEmpty()) {
+            return new CommandResponse(
+                type: 'join-error',
+                shouldShowErrorToast: true,
+                message: empty($query) ? "No active channels found." : "No channels found matching '{$query}'."
+            );
+        }
+        
+        $channelsList = $results->map(function ($session) {
+            return "- `#{$session->short_code}` – {$session->display_name}";
+        })->join("\n");
+        
+        $title = empty($query) ? 'Available Channels' : "Channels matching '{$query}'";
+        $message = "**{$title}**\n\n{$channelsList}\n\nType `/join #c5` to join a specific channel.";
+        
+        return new CommandResponse(
+            type: 'join-channels',
+            shouldOpenPanel: true,
+            panelData: [
+                'message' => $message,
+                'channels' => $results->map(function ($session) {
+                    return [
+                        'id' => $session->id,
+                        'short_code' => $session->short_code,
+                        'display_name' => $session->display_name,
+                        'channel_display' => $session->channel_display,
+                        'last_activity' => $session->last_activity_at?->diffForHumans()
+                    ];
+                })->toArray()
+            ]
+        );
+    }
+}

--- a/app/Actions/Commands/NameCommand.php
+++ b/app/Actions/Commands/NameCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Actions\Commands;
+
+use App\Contracts\HandlesCommand;
+use App\DTOs\CommandRequest;
+use App\DTOs\CommandResponse;
+use App\Models\ChatSession;
+
+class NameCommand implements HandlesCommand
+{
+    public function handle(CommandRequest $command): CommandResponse
+    {
+        $customName = trim($command->arguments['identifier'] ?? '');
+        
+        // Get current chat session ID from the command context
+        $currentChatSessionId = $command->arguments['current_chat_session_id'] ?? null;
+        
+        if (!$currentChatSessionId) {
+            return new CommandResponse(
+                type: 'name-error',
+                shouldShowErrorToast: true,
+                message: "No active chat session to rename. Start a conversation first."
+            );
+        }
+        
+        if (empty($customName)) {
+            return $this->showNameHelp();
+        }
+        
+        // Handle special case: if name starts with #, remove it
+        if (str_starts_with($customName, '#')) {
+            $customName = substr($customName, 1);
+        }
+        
+        // Validate custom name
+        if (strlen($customName) < 2 || strlen($customName) > 50) {
+            return new CommandResponse(
+                type: 'name-error',
+                shouldShowErrorToast: true,
+                message: "Channel name must be between 2 and 50 characters."
+            );
+        }
+        
+        // Find and update the chat session
+        $chatSession = ChatSession::find($currentChatSessionId);
+        if (!$chatSession) {
+            return new CommandResponse(
+                type: 'name-error',
+                shouldShowErrorToast: true,
+                message: "Current chat session not found."
+            );
+        }
+        
+        $oldName = $chatSession->custom_name ?: $chatSession->title;
+        $chatSession->update(['custom_name' => $customName]);
+        
+        return new CommandResponse(
+            type: 'name-success',
+            shouldShowSuccessToast: true,
+            toastData: [
+                'title' => 'Channel Renamed',
+                'message' => "Changed from '{$oldName}' to '#{$chatSession->short_code} {$customName}'",
+                'fragmentType' => 'chat',
+                'fragmentId' => null
+            ]
+        );
+    }
+    
+    private function showNameHelp(): CommandResponse
+    {
+        $message = <<<MARKDOWN
+# Set Channel Name
+
+Usage:
+- `/name My Project Chat` – Set custom name for current channel
+- `/name #ProjectAlpha` – Set name (# is optional)
+
+The current channel will be renamed and the new name will appear in the sidebar.
+
+**Current naming:**
+- Short code: Always preserved (e.g., `#c5`)
+- Custom name: Replaces the auto-generated title
+- Display format: `#c5 Your Custom Name`
+MARKDOWN;
+
+        return new CommandResponse(
+            type: 'help',
+            shouldOpenPanel: true,
+            panelData: [
+                'message' => $message,
+            ],
+        );
+    }
+}

--- a/app/DTOs/CommandResponse.php
+++ b/app/DTOs/CommandResponse.php
@@ -21,6 +21,8 @@ class CommandResponse
     public ?array $toastData = []; // 👈 NEW! Data for toast display
 
     public bool $shouldShowErrorToast = false; // 👈 NEW! For error toast notifications
+    
+    public ?array $data = []; // 👈 NEW! Additional command data
 
     public function __construct(
         ?string $message = null,
@@ -31,7 +33,8 @@ class CommandResponse
         ?array $panelData = [],
         bool $shouldShowSuccessToast = false,
         ?array $toastData = [],
-        bool $shouldShowErrorToast = false
+        bool $shouldShowErrorToast = false,
+        ?array $data = []
     ) {
         $this->message = $message;
         $this->type = $type;
@@ -42,5 +45,6 @@ class CommandResponse
         $this->shouldShowSuccessToast = $shouldShowSuccessToast;
         $this->toastData = $toastData ?? [];
         $this->shouldShowErrorToast = $shouldShowErrorToast;
+        $this->data = $data ?? [];
     }
 }

--- a/app/Services/CommandRegistry.php
+++ b/app/Services/CommandRegistry.php
@@ -11,6 +11,9 @@ use App\Actions\Commands\RecallCommand;
 use App\Actions\Commands\SearchCommand;
 use App\Actions\Commands\SessionCommand;
 use App\Actions\Commands\TodoCommand;
+use App\Actions\Commands\JoinCommand;
+use App\Actions\Commands\ChannelsCommand;
+use App\Actions\Commands\NameCommand;
 
 class CommandRegistry
 {
@@ -26,6 +29,10 @@ class CommandRegistry
         's' => SearchCommand::class, // alias for search
         'todo' => TodoCommand::class,
         't' => TodoCommand::class, // alias for todo
+        'join' => JoinCommand::class,
+        'j' => JoinCommand::class, // alias for join
+        'channels' => ChannelsCommand::class,
+        'name' => NameCommand::class,
         // 'export' => ExportCommand::class (future)
     ];
 

--- a/database/migrations/2025_09_01_022243_add_short_code_and_custom_name_to_chat_sessions_table.php
+++ b/database/migrations/2025_09_01_022243_add_short_code_and_custom_name_to_chat_sessions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('chat_sessions', function (Blueprint $table) {
+            $table->string('short_code')->nullable()->unique()->after('title');
+            $table->string('custom_name')->nullable()->after('short_code');
+            $table->index('short_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('chat_sessions', function (Blueprint $table) {
+            $table->dropIndex(['short_code']);
+            $table->dropColumn(['short_code', 'custom_name']);
+        });
+    }
+};

--- a/database/migrations/2025_09_01_022302_backfill_chat_session_short_codes.php
+++ b/database/migrations/2025_09_01_022302_backfill_chat_session_short_codes.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Generate short codes for existing chat sessions
+        $chatSessions = \App\Models\ChatSession::whereNull('short_code')
+            ->orderBy('id')
+            ->get();
+        
+        $counter = 1;
+        foreach ($chatSessions as $session) {
+            $shortCode = 'c' . $counter;
+            $session->update(['short_code' => $shortCode]);
+            $counter++;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Clear all short codes
+        \App\Models\ChatSession::query()->update(['short_code' => null]);
+    }
+};

--- a/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
+++ b/resources/views/filament/resources/fragment-resource/pages/chat-interface.blade.php
@@ -195,8 +195,8 @@
                                 <x-heroicon-o-bars-2 class="w-3 h-3"/>
                             </div>
                             <div class="flex-1 min-w-0 mr-2">
-                                <span class="text-sm {{ $session['id'] === $currentChatSessionId ? 'text-hot-pink' : 'text-gray-300' }} truncate block" title="{{ $session['title'] }}">
-                                    {{ $session['title'] }}
+                                <span class="text-sm {{ $session['id'] === $currentChatSessionId ? 'text-hot-pink' : 'text-gray-300' }} truncate block" title="{{ $session['channel_display'] ?? $session['title'] }}">
+                                    {{ $session['channel_display'] ?? $session['title'] }}
                                 </span>
                             </div>
                             <span class="px-1.5 py-0.5 text-xs rounded-full {{ $session['id'] === $currentChatSessionId ? 'bg-hot-pink/30 text-hot-pink' : 'bg-neon-cyan/20 text-neon-cyan' }} font-medium">
@@ -256,8 +256,8 @@
                                 }}"
                         >
                             <div class="flex-1 min-w-0 mr-2">
-                                <span class="text-sm {{ $session['id'] === $currentChatSessionId ? 'text-hot-pink' : 'text-gray-300' }} truncate block" title="{{ $session['title'] }}">
-                                    {{ $session['title'] }}
+                                <span class="text-sm {{ $session['id'] === $currentChatSessionId ? 'text-hot-pink' : 'text-gray-300' }} truncate block" title="{{ $session['channel_display'] ?? $session['title'] }}">
+                                    {{ $session['channel_display'] ?? $session['title'] }}
                                 </span>
                             </div>
                             <span class="px-1.5 py-0.5 text-xs rounded-full {{ $session['id'] === $currentChatSessionId ? 'bg-hot-pink/30 text-hot-pink' : 'bg-electric-blue/20 text-electric-blue' }} font-medium">

--- a/resources/views/livewire/command-result.blade.php
+++ b/resources/views/livewire/command-result.blade.php
@@ -152,6 +152,72 @@
                 </div>
             @endif
 
+        @elseif ($type === 'join-channels')
+            {{-- Join Channel Results --}}
+            @if (isset($data['message']))
+                <div class="prose prose-sm max-w-none text-text-primary mb-3">
+                    <x-chat-markdown :fragment="null">
+                        {{ $data['message'] }}
+                    </x-chat-markdown>
+                </div>
+            @endif
+
+            @if (isset($data['channels']) && count($data['channels']) > 0)
+                <div class="space-y-2">
+                    @foreach ($data['channels'] as $channel)
+                        <div 
+                            wire:click="$dispatch('join-channel', { chatId: {{ $channel['id'] }} })"
+                            class="flex items-center justify-between p-3 rounded-lg bg-surface border border-electric-blue/20 hover:border-electric-blue/40 cursor-pointer transition-all group">
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-center space-x-2">
+                                    <span class="text-sm font-mono text-electric-blue">{{ $channel['short_code'] }}</span>
+                                    <span class="text-sm text-text-primary truncate">{{ $channel['display_name'] }}</span>
+                                </div>
+                                @if (isset($channel['last_activity']))
+                                    <div class="text-xs text-text-muted mt-1">{{ $channel['last_activity'] }}</div>
+                                @endif
+                            </div>
+                            <div class="text-xs text-electric-blue/60 group-hover:text-electric-blue transition-colors">
+                                Click to join →
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+
+        @elseif ($type === 'channels-list')
+            {{-- Channels List Results --}}
+            @if (isset($data['message']))
+                <div class="prose prose-sm max-w-none text-text-primary mb-3">
+                    <x-chat-markdown :fragment="null">
+                        {{ $data['message'] }}
+                    </x-chat-markdown>
+                </div>
+            @endif
+
+            @if (isset($data['channels']) && count($data['channels']) > 0)
+                <div class="space-y-2 mt-4">
+                    @foreach ($data['channels'] as $channel)
+                        <div 
+                            wire:click="$dispatch('join-channel', { chatId: {{ $channel['id'] }} })"
+                            class="flex items-center justify-between p-3 rounded-lg bg-surface border border-electric-blue/20 hover:border-electric-blue/40 cursor-pointer transition-all group">
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-center space-x-2">
+                                    <span class="text-sm font-mono text-electric-blue">{{ $channel['short_code'] }}</span>
+                                    <span class="text-sm text-text-primary truncate">{{ $channel['display_name'] }}</span>
+                                </div>
+                                @if (isset($channel['last_activity']))
+                                    <div class="text-xs text-text-muted mt-1">{{ $channel['last_activity'] }}</div>
+                                @endif
+                            </div>
+                            <div class="text-xs text-electric-blue/60 group-hover:text-electric-blue transition-colors">
+                                Click to join →
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+
         @elseif ($type === 'search')
             {{-- Search Results --}}
             @if (isset($data['message']))


### PR DESCRIPTION
## Summary
- Implements complete `/join` command system with auto-generated short codes (#c1, #c2, etc.) and custom channel names
- Users can navigate channels like IRC: `/join #c5`, `/join #CustomName`, `/join search`, `/channels`
- Adds channel renaming with `/name` command and comprehensive help documentation
- Fixes critical parsing bug where `/join #custom` showed help instead of joining channel

## Key Features
- **Auto-generated short codes**: All chat sessions get unique codes (c1, c2, c3...)
- **Custom channel names**: Replace default display entirely (e.g., `#ProjectAlpha`)
- **Multiple join methods**: By short code, custom name, or search terms
- **Interactive UI**: Channel listing with click-to-join functionality
- **Command aliases**: `/j` for join, `/help sessions` alias

## Technical Changes
- Database migrations for `short_code` and `custom_name` columns with PostgreSQL compatibility
- New command classes: `JoinCommand`, `ChannelsCommand`, `NameCommand`
- Updated `ParseSlashCommand` to correctly handle `#` prefixes for channel identifiers vs hashtags
- Enhanced sidebar display with channel format support
- Command mode state management improvements

## Test Plan
- [x] Test `/join #c5` joins by short code
- [x] Test `/join #CustomName` joins by custom name  
- [x] Test `/join search` finds and joins channels
- [x] Test `/channels` lists all available channels
- [x] Test `/name Custom` renames current channel
- [x] Test `/help join` shows channel navigation help
- [x] Test sidebar displays correct channel format
- [x] Verify migrations run successfully on PostgreSQL

🤖 Generated with [Claude Code](https://claude.ai/code)