### PR TITLE
fix: resolve temporal dead zone error in chat message sending

### DIFF
--- a/resources/js/islands/chat/ChatIsland.tsx
+++ b/resources/js/islands/chat/ChatIsland.tsx
@@ -107,10 +107,10 @@ export default function ChatIsland() {
       activeStreamRef.current = null
     }
 
+    const streamSessionId = currentSessionId // Capture session ID at start of stream
     const userId = uuid(`user-${streamSessionId}`)
     const userMessage: ChatMessage = { id: userId, role: 'user', md: content }
     const updatedMessages = [...messages, userMessage]
-    const streamSessionId = currentSessionId // Capture session ID at start of stream
     setMessages(updatedMessages)
     setSending(true)
 


### PR DESCRIPTION
## Summary

**Critical fix** for chat message sending functionality that was broken by temporal dead zone error.

## Issue

In the previous React key duplication fix, `streamSessionId` was used in a `uuid()` call before being declared, causing a ReferenceError that prevented all chat message sending:

```typescript
// ❌ BROKEN: Using variable before declaration
const userId = uuid(`user-${streamSessionId}`)  // Line 110 - ReferenceError!  
const streamSessionId = currentSessionId        // Line 113 - declared after use
```

## Solution

Moved the `streamSessionId` declaration before its usage:

```typescript
// ✅ FIXED: Declare before use
const streamSessionId = currentSessionId        // Moved to before usage
const userId = uuid(`user-${streamSessionId}`)  // Now safe to use
```

## Result

✅ **Chat sending functionality restored**  
✅ **No more ReferenceError on message send**  
✅ **All sessions can send messages normally**  
✅ **Maintains unique React keys from previous fix**

## Testing

- Chat message sending works in all sessions
- No JavaScript errors in console
- Maintains React key uniqueness for user/assistant message pairs