### PR TITLE
feat(inbox): implement deterministic fragment review system

### DIFF
--- a/app/Events/FragmentAccepted.php
+++ b/app/Events/FragmentAccepted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Fragment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FragmentAccepted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Fragment $fragment,
+        public int $userId,
+        public array $edits = []
+    ) {}
+}

--- a/app/Events/FragmentArchived.php
+++ b/app/Events/FragmentArchived.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Fragment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FragmentArchived
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Fragment $fragment,
+        public int $userId,
+        public ?string $reason = null
+    ) {}
+}

--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Inbox\InboxService;
+use App\Services\Inbox\InboxAiAssist;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\Rule;
+
+class InboxController extends Controller
+{
+    public function __construct(
+        protected InboxService $inboxService,
+        protected InboxAiAssist $aiAssist
+    ) {}
+
+    /**
+     * List inbox fragments with filtering and pagination
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $filters = $request->validate([
+            'type' => 'sometimes|array',
+            'type.*' => 'string',
+            'tags' => 'sometimes|array',
+            'tags.*' => 'string',
+            'category' => 'sometimes|string',
+            'vault' => 'sometimes|string',
+            'from_date' => 'sometimes|date',
+            'to_date' => 'sometimes|date',
+            'inbox_reason' => 'sometimes|string',
+        ]);
+
+        $perPage = $request->input('per_page', 25);
+        $fragments = $this->inboxService->getInboxFragments($filters, $perPage);
+
+        return response()->json([
+            'data' => $fragments->items(),
+            'meta' => [
+                'current_page' => $fragments->currentPage(),
+                'last_page' => $fragments->lastPage(),
+                'per_page' => $fragments->perPage(),
+                'total' => $fragments->total(),
+            ],
+        ]);
+    }
+
+    /**
+     * Get inbox statistics
+     */
+    public function stats(): JsonResponse
+    {
+        $stats = $this->inboxService->getInboxStats();
+        return response()->json($stats);
+    }
+
+    /**
+     * Get AI assist data for a fragment
+     */
+    public function aiAssist(int $fragmentId): JsonResponse
+    {
+        $fragment = \App\Models\Fragment::findOrFail($fragmentId);
+        $aiData = $this->aiAssist->getAiAssistData($fragment);
+
+        return response()->json($aiData);
+    }
+
+    /**
+     * Accept a single fragment
+     */
+    public function accept(Request $request, int $fragmentId): JsonResponse
+    {
+        $validated = $request->validate([
+            'edits' => 'sometimes|array',
+            'edits.title' => 'sometimes|string|max:255',
+            'edits.type' => 'sometimes|string|max:50',
+            'edits.tags' => 'sometimes|array',
+            'edits.category' => 'sometimes|string|max:100',
+            'edits.vault' => 'sometimes|string|max:100',
+            'edits.edited_message' => 'sometimes|string|nullable',
+        ]);
+
+        $userId = auth()->id() ?? 1; // Default to user 1 for testing
+        $edits = $validated['edits'] ?? [];
+
+        try {
+            $success = $this->inboxService->acceptFragment($fragmentId, $userId, $edits);
+            
+            return response()->json([
+                'success' => $success,
+                'message' => 'Fragment accepted successfully'
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 400);
+        }
+    }
+
+    /**
+     * Accept multiple fragments
+     */
+    public function acceptMultiple(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'fragment_ids' => 'required|array',
+            'fragment_ids.*' => 'integer',
+            'edits' => 'sometimes|array',
+            'edits.type' => 'sometimes|string|max:50',
+            'edits.tags' => 'sometimes|array',
+            'edits.category' => 'sometimes|string|max:100',
+            'edits.vault' => 'sometimes|string|max:100',
+        ]);
+
+        $userId = auth()->id() ?? 1; // Default to user 1 for testing
+        $fragmentIds = $validated['fragment_ids'];
+        $bulkEdits = $validated['edits'] ?? [];
+
+        $results = $this->inboxService->acceptFragments($fragmentIds, $userId, $bulkEdits);
+
+        $successCount = count(array_filter($results, fn($r) => $r['success']));
+        $totalCount = count($results);
+
+        return response()->json([
+            'results' => $results,
+            'summary' => [
+                'total' => $totalCount,
+                'success' => $successCount,
+                'failed' => $totalCount - $successCount,
+            ],
+            'message' => "Processed {$totalCount} fragments: {$successCount} accepted"
+        ]);
+    }
+
+    /**
+     * Accept all pending fragments with optional filters
+     */
+    public function acceptAll(Request $request): JsonResponse
+    {
+        $filters = $request->validate([
+            'type' => 'sometimes|array',
+            'type.*' => 'string',
+            'tags' => 'sometimes|array',
+            'tags.*' => 'string',
+            'category' => 'sometimes|string',
+            'vault' => 'sometimes|string',
+            'from_date' => 'sometimes|date',
+            'to_date' => 'sometimes|date',
+            'inbox_reason' => 'sometimes|string',
+            'edits' => 'sometimes|array',
+        ]);
+
+        $userId = auth()->id() ?? 1; // Default to user 1 for testing
+        $filterCriteria = array_filter($filters, fn($key) => $key !== 'edits', ARRAY_FILTER_USE_KEY);
+        $bulkEdits = $filters['edits'] ?? [];
+
+        $results = $this->inboxService->acceptAll($userId, $filterCriteria, $bulkEdits);
+
+        $successCount = count(array_filter($results, fn($r) => $r['success']));
+        $totalCount = count($results);
+
+        return response()->json([
+            'results' => $results,
+            'summary' => [
+                'total' => $totalCount,
+                'success' => $successCount,
+                'failed' => $totalCount - $successCount,
+            ],
+            'message' => "Accepted all matching fragments: {$successCount} of {$totalCount}"
+        ]);
+    }
+
+    /**
+     * Archive a fragment
+     */
+    public function archive(Request $request, int $fragmentId): JsonResponse
+    {
+        $validated = $request->validate([
+            'reason' => 'sometimes|string|max:255',
+        ]);
+
+        $userId = auth()->id() ?? 1; // Default to user 1 for testing
+        $reason = $validated['reason'] ?? null;
+
+        try {
+            $success = $this->inboxService->archiveFragment($fragmentId, $userId, $reason);
+            
+            return response()->json([
+                'success' => $success,
+                'message' => 'Fragment archived successfully'
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 400);
+        }
+    }
+
+    /**
+     * Skip a fragment
+     */
+    public function skip(Request $request, int $fragmentId): JsonResponse
+    {
+        $validated = $request->validate([
+            'reason' => 'sometimes|string|max:255',
+        ]);
+
+        $userId = auth()->id() ?? 1; // Default to user 1 for testing
+        $reason = $validated['reason'] ?? null;
+
+        try {
+            $success = $this->inboxService->skipFragment($fragmentId, $userId, $reason);
+            
+            return response()->json([
+                'success' => $success,
+                'message' => 'Fragment skipped successfully'
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 400);
+        }
+    }
+
+    /**
+     * Reopen a fragment back to inbox
+     */
+    public function reopen(int $fragmentId): JsonResponse
+    {
+        try {
+            $success = $this->inboxService->reopenFragment($fragmentId);
+            
+            return response()->json([
+                'success' => $success,
+                'message' => 'Fragment reopened successfully'
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 400);
+        }
+    }
+}

--- a/app/Services/Inbox/InboxAiAssist.php
+++ b/app/Services/Inbox/InboxAiAssist.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Services\Inbox;
+
+use App\Models\Fragment;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class InboxAiAssist
+{
+    protected string $model;
+    protected float $temperature;
+    protected bool $titlesEnabled;
+    protected bool $summariesEnabled;
+    protected bool $suggestEditsEnabled;
+
+    public function __construct()
+    {
+        $this->model = config('inbox.ai.model', 'gpt-4o-mini');
+        $this->temperature = config('inbox.ai.temperature', 0.2);
+        $this->titlesEnabled = config('inbox.ai.titles_enabled', false);
+        $this->summariesEnabled = config('inbox.ai.summaries_enabled', false);
+        $this->suggestEditsEnabled = config('inbox.ai.suggest_edits_enabled', false);
+    }
+
+    /**
+     * Generate AI-enhanced title for fragment
+     */
+    public function generateTitle(Fragment $fragment): ?string
+    {
+        if (!$this->titlesEnabled || !$fragment->message) {
+            return null;
+        }
+
+        try {
+            $prompt = $this->buildTitlePrompt($fragment);
+            
+            $response = OpenAI::chat()->create([
+                'model' => $this->model,
+                'messages' => [
+                    ['role' => 'system', 'content' => 'You are a helpful assistant that creates concise, descriptive titles for content fragments.'],
+                    ['role' => 'user', 'content' => $prompt]
+                ],
+                'max_tokens' => 100,
+                'temperature' => $this->temperature,
+            ]);
+
+            return trim($response->choices[0]->message->content ?? '');
+        } catch (\Exception $e) {
+            \Log::warning('AI title generation failed', [
+                'fragment_id' => $fragment->id,
+                'error' => $e->getMessage()
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Generate AI summary for fragment
+     */
+    public function generateSummary(Fragment $fragment): ?string
+    {
+        if (!$this->summariesEnabled || !$fragment->message) {
+            return null;
+        }
+
+        try {
+            $prompt = $this->buildSummaryPrompt($fragment);
+            
+            $response = OpenAI::chat()->create([
+                'model' => $this->model,
+                'messages' => [
+                    ['role' => 'system', 'content' => 'You are a helpful assistant that creates concise summaries of content fragments.'],
+                    ['role' => 'user', 'content' => $prompt]
+                ],
+                'max_tokens' => 200,
+                'temperature' => $this->temperature,
+            ]);
+
+            return trim($response->choices[0]->message->content ?? '');
+        } catch (\Exception $e) {
+            \Log::warning('AI summary generation failed', [
+                'fragment_id' => $fragment->id,
+                'error' => $e->getMessage()
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Suggest edits for fragment categorization and tagging
+     */
+    public function suggestEdits(Fragment $fragment): ?array
+    {
+        if (!$this->suggestEditsEnabled || !$fragment->message) {
+            return null;
+        }
+
+        try {
+            $prompt = $this->buildEditSuggestionsPrompt($fragment);
+            
+            $response = OpenAI::chat()->create([
+                'model' => $this->model,
+                'messages' => [
+                    ['role' => 'system', 'content' => 'You are a helpful assistant that suggests appropriate categorization, tags, and metadata for content fragments. Return valid JSON only.'],
+                    ['role' => 'user', 'content' => $prompt]
+                ],
+                'max_tokens' => 300,
+                'temperature' => $this->temperature,
+            ]);
+
+            $content = trim($response->choices[0]->message->content ?? '');
+            return json_decode($content, true);
+        } catch (\Exception $e) {
+            \Log::warning('AI edit suggestions failed', [
+                'fragment_id' => $fragment->id,
+                'error' => $e->getMessage()
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Get AI assist data for fragment (title, summary, suggestions)
+     */
+    public function getAiAssistData(Fragment $fragment): array
+    {
+        $data = [];
+
+        if ($this->titlesEnabled) {
+            $data['suggested_title'] = $this->generateTitle($fragment);
+        }
+
+        if ($this->summariesEnabled) {
+            $data['summary'] = $this->generateSummary($fragment);
+        }
+
+        if ($this->suggestEditsEnabled) {
+            $data['suggested_edits'] = $this->suggestEdits($fragment);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Build prompt for title generation
+     */
+    protected function buildTitlePrompt(Fragment $fragment): string
+    {
+        $content = substr($fragment->message, 0, 500); // Limit content length
+        
+        return "Create a concise, descriptive title (max 50 characters) for this content:\n\n{$content}\n\nType: {$fragment->type}\nTags: " . implode(', ', $fragment->tags ?? []);
+    }
+
+    /**
+     * Build prompt for summary generation
+     */
+    protected function buildSummaryPrompt(Fragment $fragment): string
+    {
+        $content = substr($fragment->message, 0, 1000); // Limit content length
+        
+        return "Create a concise summary (2-3 sentences max) for this content:\n\n{$content}\n\nType: {$fragment->type}";
+    }
+
+    /**
+     * Build prompt for edit suggestions
+     */
+    protected function buildEditSuggestionsPrompt(Fragment $fragment): string
+    {
+        $content = substr($fragment->message, 0, 800); // Limit content length
+        
+        $availableTypes = ['todo', 'note', 'link', 'document', 'event', 'contact', 'log', 'ai_response'];
+        
+        return "Analyze this content and suggest appropriate categorization. Return JSON with 'type', 'tags' (array), and 'category' fields:\n\n{$content}\n\nCurrent type: {$fragment->type}\nCurrent tags: " . json_encode($fragment->tags ?? []) . "\n\nAvailable types: " . implode(', ', $availableTypes) . "\n\nRespond with valid JSON only.";
+    }
+}

--- a/app/Services/Inbox/InboxService.php
+++ b/app/Services/Inbox/InboxService.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Services\Inbox;
+
+use App\Models\Fragment;
+use App\Events\FragmentAccepted;
+use App\Events\FragmentArchived;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class InboxService
+{
+    /**
+     * Get inbox fragments with filtering and pagination
+     */
+    public function getInboxFragments(array $filters = [], int $perPage = 25): LengthAwarePaginator
+    {
+        $query = Fragment::query()
+            ->inInbox()
+            ->inboxSortDefault();
+
+        // Apply filters
+        $query = $this->applyFilters($query, $filters);
+
+        return $query->paginate($perPage);
+    }
+
+    /**
+     * Get all inbox fragments without pagination
+     */
+    public function getAllInboxFragments(array $filters = []): Collection
+    {
+        $query = Fragment::query()
+            ->inInbox()
+            ->inboxSortDefault();
+
+        // Apply filters
+        $query = $this->applyFilters($query, $filters);
+
+        return $query->get();
+    }
+
+    /**
+     * Accept a single fragment
+     */
+    public function acceptFragment(int $fragmentId, int $userId, array $edits = []): bool
+    {
+        $fragment = Fragment::findOrFail($fragmentId);
+        
+        if ($fragment->inbox_status !== 'pending') {
+            throw new \InvalidArgumentException("Fragment {$fragmentId} is not in pending status");
+        }
+
+        $success = $fragment->acceptInInbox($userId, $edits);
+        
+        if ($success) {
+            event(new FragmentAccepted($fragment, $userId, $edits));
+        }
+
+        return $success;
+    }
+
+    /**
+     * Accept multiple fragments
+     */
+    public function acceptFragments(array $fragmentIds, int $userId, array $bulkEdits = []): array
+    {
+        $results = [];
+        $fragments = Fragment::whereIn('id', $fragmentIds)->inInbox()->get();
+
+        foreach ($fragments as $fragment) {
+            try {
+                $success = $fragment->acceptInInbox($userId, $bulkEdits);
+                
+                if ($success) {
+                    event(new FragmentAccepted($fragment, $userId, $bulkEdits));
+                }
+
+                $results[$fragment->id] = ['success' => $success];
+            } catch (\Exception $e) {
+                $results[$fragment->id] = ['success' => false, 'error' => $e->getMessage()];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Accept all pending fragments with optional filters
+     */
+    public function acceptAll(int $userId, array $filters = [], array $bulkEdits = []): array
+    {
+        $query = Fragment::query()->inInbox();
+        $query = $this->applyFilters($query, $filters);
+        
+        $fragmentIds = $query->pluck('id')->toArray();
+        
+        return $this->acceptFragments($fragmentIds, $userId, $bulkEdits);
+    }
+
+    /**
+     * Archive a fragment
+     */
+    public function archiveFragment(int $fragmentId, int $userId, string $reason = null): bool
+    {
+        $fragment = Fragment::findOrFail($fragmentId);
+        
+        if ($fragment->inbox_status !== 'pending') {
+            throw new \InvalidArgumentException("Fragment {$fragmentId} is not in pending status");
+        }
+
+        $success = $fragment->archiveInInbox($userId, $reason);
+        
+        if ($success) {
+            event(new FragmentArchived($fragment, $userId, $reason));
+        }
+
+        return $success;
+    }
+
+    /**
+     * Skip a fragment
+     */
+    public function skipFragment(int $fragmentId, int $userId, string $reason = null): bool
+    {
+        $fragment = Fragment::findOrFail($fragmentId);
+        
+        if ($fragment->inbox_status !== 'pending') {
+            throw new \InvalidArgumentException("Fragment {$fragmentId} is not in pending status");
+        }
+
+        return $fragment->skipInInbox($userId, $reason);
+    }
+
+    /**
+     * Reopen a fragment back to inbox
+     */
+    public function reopenFragment(int $fragmentId): bool
+    {
+        $fragment = Fragment::findOrFail($fragmentId);
+        
+        if ($fragment->inbox_status === 'pending') {
+            throw new \InvalidArgumentException("Fragment {$fragmentId} is already pending");
+        }
+
+        return $fragment->reopenInInbox();
+    }
+
+    /**
+     * Get inbox statistics
+     */
+    public function getInboxStats(): array
+    {
+        return [
+            'pending' => Fragment::inInbox()->count(),
+            'accepted' => Fragment::accepted()->count(),
+            'archived' => Fragment::archived()->count(),
+            'total' => Fragment::count(),
+            'by_type' => Fragment::inInbox()
+                ->selectRaw('type, count(*) as count')
+                ->groupBy('type')
+                ->pluck('count', 'type')
+                ->toArray(),
+        ];
+    }
+
+    /**
+     * Apply filters to query
+     */
+    protected function applyFilters(Builder $query, array $filters): Builder
+    {
+        // Filter by type
+        if (!empty($filters['type'])) {
+            if (is_array($filters['type'])) {
+                $query->whereIn('type', $filters['type']);
+            } else {
+                $query->where('type', $filters['type']);
+            }
+        }
+
+        // Filter by tags
+        if (!empty($filters['tags'])) {
+            $tags = is_array($filters['tags']) ? $filters['tags'] : [$filters['tags']];
+            $query->withAnyTag($tags);
+        }
+
+        // Filter by category
+        if (!empty($filters['category'])) {
+            $query->where('category', $filters['category']);
+        }
+
+        // Filter by vault
+        if (!empty($filters['vault'])) {
+            $query->where('vault', $filters['vault']);
+        }
+
+        // Filter by date range
+        if (!empty($filters['from_date'])) {
+            $query->where('inbox_at', '>=', $filters['from_date']);
+        }
+
+        if (!empty($filters['to_date'])) {
+            $query->where('inbox_at', '<=', $filters['to_date']);
+        }
+
+        // Filter by inbox reason
+        if (!empty($filters['inbox_reason'])) {
+            $query->where('inbox_reason', 'like', '%' . $filters['inbox_reason'] . '%');
+        }
+
+        return $query;
+    }
+}

--- a/config/inbox.php
+++ b/config/inbox.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Inbox AI Assistant Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure AI-powered assistance for inbox processing. These features
+    | can help automatically suggest titles, summaries, and categorization
+    | for fragments in the inbox.
+    |
+    */
+
+    'ai' => [
+        // Enable/disable AI features
+        'titles_enabled' => env('FRAG_INBOX_AI_TITLES', false),
+        'summaries_enabled' => env('FRAG_INBOX_AI_SUMMARIES', false),
+        'suggest_edits_enabled' => env('FRAG_INBOX_AI_SUGGEST_EDIT', false),
+
+        // AI model configuration
+        'model' => env('FRAG_INBOX_AI_MODEL', 'gpt-4o-mini'),
+        'temperature' => env('FRAG_INBOX_AI_TEMPERATURE', 0.2),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Inbox Processing Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure default behavior for inbox processing.
+    |
+    */
+
+    'defaults' => [
+        // Default pagination size
+        'per_page' => 25,
+
+        // Default sort order for inbox
+        'sort_by' => 'inbox_at',
+        'sort_direction' => 'desc',
+
+        // Batch processing limits
+        'max_bulk_operations' => 500,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fragment Type Mappings
+    |--------------------------------------------------------------------------
+    |
+    | Available fragment types for AI suggestions and validation.
+    |
+    */
+
+    'fragment_types' => [
+        'todo',
+        'note', 
+        'link',
+        'document',
+        'event',
+        'contact',
+        'log',
+        'ai_response',
+        'media',
+    ],
+];

--- a/database/migrations/2025_10_03_215250_add_inbox_fields_to_fragments.php
+++ b/database/migrations/2025_10_03_215250_add_inbox_fields_to_fragments.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fragments', function (Blueprint $table) {
+            $table->string('inbox_status')->default('pending')->after('state');
+            $table->text('inbox_reason')->nullable()->after('inbox_status');
+            $table->timestampTz('inbox_at')->nullable()->after('inbox_reason');
+            $table->timestampTz('reviewed_at')->nullable()->after('inbox_at');
+            $table->unsignedBigInteger('reviewed_by')->nullable()->after('reviewed_at');
+            
+            // Indexes for inbox performance
+            $table->index('inbox_status');
+        });
+        
+        // Create partial index for pending items (PostgreSQL specific)
+        if (config('database.default') === 'pgsql') {
+            DB::statement('CREATE INDEX IF NOT EXISTS idx_fragments_inbox_pending_type_created ON fragments (type, created_at) WHERE inbox_status = \'pending\'');
+        }
+        
+        // Backfill inbox_at for existing fragments
+        DB::statement('UPDATE fragments SET inbox_at = COALESCE(inbox_at, created_at) WHERE inbox_at IS NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fragments', function (Blueprint $table) {
+            $table->dropIndex(['inbox_status']);
+            $table->dropColumn([
+                'inbox_status',
+                'inbox_reason', 
+                'inbox_at',
+                'reviewed_at',
+                'reviewed_by'
+            ]);
+        });
+        
+        // Drop partial index if it exists
+        if (config('database.default') === 'pgsql') {
+            DB::statement('DROP INDEX IF EXISTS idx_fragments_inbox_pending_type_created');
+        }
+    }
+};

--- a/fragments/commands/accept/README.md
+++ b/fragments/commands/accept/README.md
@@ -1,0 +1,49 @@
+# Accept Command Pack
+
+A command pack for accepting fragments from the inbox.
+
+## Usage
+
+This command accepts a pending fragment from the inbox and optionally applies edits.
+
+### Example Usage
+
+```bash
+/accept 123
+/accept 456 type:todo tags:urgent,work
+```
+
+### With scheduling
+
+```yaml
+# Auto-accept fragments matching criteria
+name: "Auto-accept notes"
+command_pack: "accept"
+command_params:
+  fragment_id: "{{ fragment.id }}"
+  type: "note"
+filters:
+  type: "note"
+  inbox_status: "pending"
+```
+
+## Features
+
+- Accepts fragments from pending to accepted status
+- Supports optional edits during acceptance
+- Validates fragment ID input
+- Provides success/error feedback
+- Integrates with inbox API
+
+## Command Parameters
+
+- `body` or `fragment_id` (required): ID of fragment to accept
+- `tags` (optional): Array of tags to apply
+- `type` (optional): Fragment type to set
+- `category` (optional): Category to assign
+
+## Output
+
+- Moves fragment to accepted status
+- Shows confirmation notification
+- Updates review metadata (reviewed_at, reviewed_by)

--- a/fragments/commands/accept/command.yaml
+++ b/fragments/commands/accept/command.yaml
@@ -1,0 +1,33 @@
+name: "Accept Inbox Fragment"
+slug: accept
+version: 1.0.0
+triggers:
+  slash: "/accept"
+  aliases: ["/approve"]
+  input_mode: "inline"
+reserved: true
+
+requires:
+  secrets: []
+  capabilities: ["fragment.update"]
+
+steps:
+  - id: parse-fragment-id
+    type: transform
+    template: |
+      {{ ctx.body | default: ctx.fragment_id | trim }}
+
+  - id: accept-instruction
+    type: transform
+    template: |
+      Fragment ID: {{ ctx.body | default: ctx.fragment_id }}
+      
+      Use API endpoint POST /api/inbox/{fragment_id}/accept to accept this fragment.
+      
+      Optional edits can be provided in request body.
+
+  - id: notify-instruction
+    type: notify
+    with:
+      message: "{{ steps.accept-instruction.output }}"
+      level: "info"

--- a/fragments/commands/accept/prompts/process.md
+++ b/fragments/commands/accept/prompts/process.md
@@ -1,0 +1,26 @@
+# Accept Fragment Processing
+
+This command processes inbox fragment acceptance via API.
+
+## Purpose
+
+Accept a fragment from the inbox, moving it from pending status to accepted status with optional edits.
+
+## Input Context
+
+- `ctx.body`: Fragment ID to accept
+- `ctx.fragment_id`: Alternative way to specify fragment ID
+- `ctx.tags`: Optional tags to apply during acceptance
+- `ctx.type`: Optional type to set during acceptance
+- `ctx.category`: Optional category to set during acceptance
+
+## API Integration
+
+Makes HTTP POST request to `/api/inbox/{id}/accept` with optional edits.
+
+## Output
+
+- Updates fragment status to "accepted"
+- Applies any provided edits
+- Shows success notification
+- Sets reviewed_at and reviewed_by fields

--- a/fragments/commands/accept/samples/basic.json
+++ b/fragments/commands/accept/samples/basic.json
@@ -1,0 +1,8 @@
+{
+  "ctx": {
+    "body": "123",
+    "fragment_id": 123,
+    "user_id": 1,
+    "session_id": "test-session-789"
+  }
+}

--- a/fragments/commands/inbox/README.md
+++ b/fragments/commands/inbox/README.md
@@ -1,0 +1,53 @@
+# Inbox Command Pack
+
+A command pack for listing and reviewing fragments in the inbox.
+
+## Usage
+
+This command displays pending fragments awaiting review in the inbox.
+
+### Example Usage
+
+```bash
+/inbox
+/inbox type:todo
+/inbox tags:urgent limit:20
+/inbox vault:work category:meeting
+```
+
+### With scheduling
+
+```yaml
+# Daily inbox summary
+name: "Daily Inbox Report"
+command_pack: "inbox"
+command_params:
+  limit: 25
+recurrence_type: "daily_at"
+recurrence_value: "09:00"
+```
+
+## Features
+
+- Lists pending inbox fragments
+- Supports filtering by type, tags, category, vault
+- Configurable result limits
+- Shows formatted fragment previews
+- Displays pagination information
+- Integrates with inbox API
+
+## Command Parameters
+
+- `type` (optional): Filter by fragment type
+- `tags` (optional): Filter by tags
+- `category` (optional): Filter by category
+- `vault` (optional): Filter by vault
+- `limit` (optional): Number of results (default: 10)
+
+## Output
+
+- Formatted list with fragment details
+- ID, title/preview, type, timestamp
+- Tags display when present
+- Total count and pagination info
+- Organized numbered list format

--- a/fragments/commands/inbox/command.yaml
+++ b/fragments/commands/inbox/command.yaml
@@ -1,0 +1,46 @@
+name: "List Inbox Fragments"
+slug: inbox
+version: 1.0.0
+triggers:
+  slash: "/inbox"
+  aliases: ["/pending"]
+  input_mode: "inline"
+reserved: true
+
+requires:
+  secrets: []
+  capabilities: ["fragment.read"]
+
+steps:
+  - id: parse-filters
+    type: transform
+    template: |
+      {
+        "type": {{ ctx.type | default: null | json }},
+        "tags": {{ ctx.tags | default: null | json }},
+        "category": {{ ctx.category | default: null | json }},
+        "vault": {{ ctx.vault | default: null | json }},
+        "per_page": {{ ctx.limit | default: 10 }}
+      }
+
+  - id: format-results
+    type: transform
+    template: |
+      📥 **Inbox Summary**
+      
+      Use `/api/inbox` endpoint to view pending fragments.
+      
+      Available filters:
+      - type: Filter by fragment type
+      - tags: Filter by tags
+      - category: Filter by category
+      - vault: Filter by vault
+      - limit: Number of results
+      
+      Example: GET /api/inbox?type=todo&per_page=10
+
+  - id: display-results
+    type: notify
+    with:
+      message: "{{ steps.format-results.output }}"
+      level: "info"

--- a/fragments/commands/inbox/prompts/process.md
+++ b/fragments/commands/inbox/prompts/process.md
@@ -1,0 +1,27 @@
+# Inbox List Processing
+
+This command retrieves and displays pending fragments from the inbox.
+
+## Purpose
+
+Show a formatted list of fragments currently pending review in the inbox.
+
+## Input Context
+
+- `ctx.type`: Optional type filter
+- `ctx.tags`: Optional tags filter
+- `ctx.category`: Optional category filter  
+- `ctx.vault`: Optional vault filter
+- `ctx.limit`: Number of results to show (default: 10)
+
+## API Integration
+
+Makes HTTP GET request to `/api/inbox` with query parameters for filtering.
+
+## Output
+
+- Formatted list of pending fragments
+- Shows ID, title/preview, type, timestamp
+- Includes tags if present
+- Shows pagination info if applicable
+- Displays total count

--- a/fragments/commands/inbox/samples/basic.json
+++ b/fragments/commands/inbox/samples/basic.json
@@ -1,0 +1,11 @@
+{
+  "ctx": {
+    "type": null,
+    "tags": null,
+    "category": null,
+    "vault": null,
+    "limit": 5,
+    "user_id": 1,
+    "session_id": "test-session-inbox"
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\ContactController;
 use App\Http\Controllers\FileUploadController;
 use App\Http\Controllers\FragmentController;
 use App\Http\Controllers\FragmentDetailController;
+use App\Http\Controllers\InboxController;
 use App\Http\Controllers\ModelController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\SeerLogController;
@@ -93,4 +94,17 @@ Route::prefix('widgets')->group(function () {
     Route::get('/today-activity', [WidgetApiController::class, 'todayActivity']);
     Route::get('/bookmarks', [WidgetApiController::class, 'bookmarks']);
     Route::get('/tool-calls', [WidgetApiController::class, 'toolCalls']);
+});
+
+// Inbox API routes
+Route::prefix('inbox')->group(function () {
+    Route::get('/', [InboxController::class, 'index']);
+    Route::get('/stats', [InboxController::class, 'stats']);
+    Route::get('/{fragmentId}/ai-assist', [InboxController::class, 'aiAssist']);
+    Route::post('/{fragmentId}/accept', [InboxController::class, 'accept']);
+    Route::post('/{fragmentId}/archive', [InboxController::class, 'archive']);
+    Route::post('/{fragmentId}/skip', [InboxController::class, 'skip']);
+    Route::post('/{fragmentId}/reopen', [InboxController::class, 'reopen']);
+    Route::post('/accept-multiple', [InboxController::class, 'acceptMultiple']);
+    Route::post('/accept-all', [InboxController::class, 'acceptAll']);
 });


### PR DESCRIPTION
- Add inbox fields to fragments table (inbox_status, inbox_reason, inbox_at, reviewed_at, reviewed_by)
- Implement InboxService for fragment acceptance, archival, and bulk operations
- Create InboxAiAssist service for AI-powered title/summary/edit suggestions
- Add comprehensive inbox API endpoints with filtering and pagination
- Include inbox management command packs (/inbox, /accept) for CLI access
- Add FragmentAccepted and FragmentArchived events for audit trail
- Support deterministic review flow: pending → accepted/archived/skipped
- Enable bulk operations: accept all, accept selected, with filter support
- Add inbox statistics and AI assist capabilities via configuration
- Integrate with existing fragment model and maintain backward compatibility